### PR TITLE
Refactor layout editor shell into reusable components

### DIFF
--- a/layout-editor/src/LayoutEditorOverview.txt
+++ b/layout-editor/src/LayoutEditorOverview.txt
@@ -53,6 +53,12 @@ plugins/layout-editor/
    ├─ search-dropdown.ts       # Autocomplete-Helfer für Select-Elemente
    ├─ seed-layouts.ts          # Legt Standard-Layouts im Vault an (z. B. Kreaturenvorlage)
    └─ ui/
+      ├─ components/
+      │  ├─ component.ts       # Abstrakte UIComponent-Basis (Lifecycle + Listener/Observer-Cleanup)
+      │  ├─ editor-shell.ts    # Hülle für Header/Stage/Inspector inkl. Panel-Resizer
+      │  ├─ primitives.ts      # Leichtgewichtige UIComponent-Wrappers für Buttons/Felder/Stacks/Status
+      │  ├─ stage.ts           # DOM-/Pointer-Logik der Bühne als UIComponent
+      │  └─ structure-tree.ts  # Strukturbaum-Komponente inkl. Drag/Drop- und Reorder-Handling
       ├─ editor-menu.ts        # Kontextmenü für Inspector & Schnellaktionen
       └─ element-tree.ts       # Generische Baumansicht für den Element-Browser
 ```
@@ -64,15 +70,19 @@ plugins/layout-editor/
 - **Zentraler Zustand (`state/layout-editor-store.ts`)** verwaltet Canvas-Maße, Elemente, Auswahl, Drag-Zustände sowie History.
   Alle Mutationen (Elemente anlegen, Container-Layouts anwenden, Undo/Redo, Layout-Metadaten) laufen über den Store, der bei
   jeder Änderung Events an die Presenter aussendet.
+- **UI-Komponenten (`ui/components/`)** kapseln wiederkehrende DOM-Strukturen als `UIComponent`-Instanzen. Der
+  `EditorShellComponent` übernimmt Header/Stage/Inspector-Hülle samt Resizer, `StageComponent` bündelt Canvas-, Kamera- und
+  Pointer-Logik, `StructureTreeComponent` verwaltet den Baum inklusive Drag/Drop/Reorder und `primitives.ts` stellt
+  Wrapper für Buttons/Felder/Stacks bereit.
 - **Presenter-Schicht:**
-  - `stage-controller.ts` baut den Canvas inklusive Kamera auf, rendert Element-Nodes und verarbeitet Pointer-Interaktionen
-    (Move/Resize, Zoom, Pan). Änderungen schreibt er ausschließlich über Store-Methoden zurück.
-  - `structure-panel.ts` generiert den Baum, delegiert Drag & Drop an den Store und nutzt den Stage-Controller, um Elemente in
-    den Fokus zu setzen.
+  - `stage-controller.ts` orchestriert Store-Synchronisation und nutzt den `StageComponent`, um DOM und Pointer-Lifecycle
+    zentral aufzubauen.
+  - `structure-panel.ts` rendert den Strukturbaum über den `StructureTreeComponent`, meldet Drag-Zustände an den Store und
+    fokussiert Elemente auf der Bühne.
   - `header-controls.ts` zeichnet Header und Exportbereich, synchronisiert Canvas-Größen, öffnet Element-/Layout-Picker und
     orchestriert Import/Export sowie Speichern (inkl. Metadaten-Updates im Store).
 - **`view.ts` als Koordinator:** instanziiert Store und Presenter, bindet Inspector und Attribute-Popover an Store-Ereignisse,
-  reagiert auf globale Shortcuts (Delete, Undo/Redo) und hält die Panel-Resizer auf Kurs.
+  reagiert auf globale Shortcuts (Delete, Undo/Redo) und hält die Panel-Resizer über den `EditorShellComponent` auf Kurs.
 - **Inspector & Inline-Bearbeitung:** `inspector-panel.ts`, `attribute-popover.ts` und `inline-edit.ts` sorgen weiterhin dafür,
   dass Canvas, Inspector und Attribute synchron bleiben. Sie pushen Änderungen nur noch über den Store, wodurch History und
   Presenter automatisch aktualisiert werden.
@@ -118,12 +128,13 @@ plugins/layout-editor/
 - Öffnet Element- und Layout-Picker, verwaltet Canvas-Größen, Import/Export sowie Speichern inkl. Statusanzeigen.
 
 ### `presenters/stage-controller.ts`
-- Baut den Canvas samt Kamera auf, rendert Element-Nodes und synchronisiert Preview-Inhalte.
-- Verarbeitet Pointer-Interaktionen (Move, Resize, Zoom, Pan) und meldet Änderungen ausschließlich über den Store.
+- Orchestriert die Bühne, initialisiert den `StageComponent` und spiegelt Store-Änderungen in die UI.
+- Delegiert DOM-/Pointer-Logik (Move, Resize, Zoom, Pan) vollständig an den `StageComponent` und ruft ausschließlich
+  Store-Methoden auf.
 
 ### `presenters/structure-panel.ts`
-- Erzeugt den Strukturbaum, erlaubt Drag & Drop zwischen Containern und fokussiert Elemente auf der Bühne.
-- Delegiert alle Mutationen an den Store.
+- Instanziiert den `StructureTreeComponent`, reicht Store-Daten weiter und fokussiert Elemente auf der Bühne.
+- Reagiert auf `onReparent`/`onReorder`-Events, ruft passende Store-Methoden auf und synchronisiert Drag-Status.
 
 ### `view.ts`
 - Dünner Koordinator (`ItemView`): instanziiert Store + Presenter, reagiert auf Store-Events und hält Inspector/Popover aktuell.
@@ -135,10 +146,33 @@ plugins/layout-editor/
 ### `attribute-popover.ts`
 - Öffnet und positioniert das Attribut-Popover, synchronisiert Änderungen über den Store und triggert Inspector-Refresh.
 
+### `ui/components/component.ts`
+- Stellt die `UIComponent`-Basisklasse bereit (Lifecycle, Listener/Observer-Verwaltung, Host-Cleanup) und die
+  `renderComponent`-Helferfunktion.
+
+### `ui/components/editor-shell.ts`
+- Kapselt die äußere Layout-Hülle (Header, Struktur-, Stage- und Inspector-Host) und steuert Panel-Resizer.
+- Meldet Größenänderungen zurück an den View, damit Breiten persistiert werden können.
+
+### `ui/components/stage.ts`
+- Enthält die komplette DOM- und Pointer-Logik der Bühne als `UIComponent`.
+- Rendert Element-Previews, verwaltet Kamera-Transformationen und interaktive Move/Resize-Flows.
+
+### `ui/components/structure-tree.ts`
+- Zeichnet den Strukturbaum, verwaltet Drag/Drop inklusive Reparenting & Reorder und emittiert gezielte Events.
+- Nutzt den `UIComponent`-Lifecycle, um Listener sauber aufzuräumen und Drop-Indikatoren zu pflegen.
+
+### `ui/components/primitives.ts`
+- Liefert Wrapper für Buttons, Felder, Stacks und Status-Anzeigen auf Basis der bestehenden `elements/ui.ts`-Primitives.
+- Erlaubt Presenter/Komponenten, UI-Elemente mit automatischem Cleanup zu mounten.
+
 ### `layout-library.ts`, `layout-picker-modal.ts`, `name-input-modal.ts`
 - Unverändert: Speichern/Laden von Layouts, Dialog zum Auswählen vorhandener Layouts, Modal für Layout-Namen.
 
 ### `tests/layout-editor-store.test.ts`
 - Prüft `LayoutEditorStore` auf elementares Verhalten (Container-Defaults, Drag & Drop via Store, Undo/Redo, Delete).
 - Nutzt die esbuild-basierte Test-Infrastruktur (`tests/run-tests.mjs`).
+
+### `tests/ui-component.test.ts`
+- Sicherstellt, dass `UIComponent` Event-Listener beim Destroy entfernt und `renderComponent` alte Instanzen ersetzt.
 

--- a/layout-editor/src/presenters/stage-controller.ts
+++ b/layout-editor/src/presenters/stage-controller.ts
@@ -1,9 +1,9 @@
 // src/presenters/stage-controller.ts
-import { MIN_ELEMENT_SIZE, isContainerType } from "../definitions";
-import { renderElementPreview } from "../element-preview";
+import { isContainerType } from "../definitions";
 import { LayoutEditorStore } from "../state/layout-editor-store";
 import { LayoutElement } from "../types";
-import { clamp, isContainerElement } from "../utils";
+import { renderComponent } from "../ui/components/component";
+import { StageComponent } from "../ui/components/stage";
 
 interface StageControllerOptions {
     host: HTMLElement;
@@ -11,422 +11,55 @@ interface StageControllerOptions {
     onSelectElement?(id: string | null): void;
 }
 
-interface InteractionCleanup {
-    (): void;
-}
-
 export class StageController {
-    private readonly elementNodes = new Map<string, HTMLElement>();
-    private canvasEl!: HTMLElement;
-    private viewportEl!: HTMLElement;
-    private cameraPanEl!: HTMLElement;
-    private cameraZoomEl!: HTMLElement;
+    private readonly component: StageComponent;
     private unsubscribe: (() => void) | null = null;
 
-    private cameraScale = 1;
-    private cameraX = 0;
-    private cameraY = 0;
-    private panPointerId: number | null = null;
-    private panStartX = 0;
-    private panStartY = 0;
-    private panOriginX = 0;
-    private panOriginY = 0;
-    private hasInitializedCamera = false;
-
     constructor(private readonly options: StageControllerOptions) {
-        this.initialize(options.host);
-        this.unsubscribe = options.store.subscribe(event => {
-            if (event.type === "state") {
-                this.syncStage(event.state.elements, event.state.selectedElementId, event.state.canvasWidth, event.state.canvasHeight);
+        this.component = new StageComponent({
+            store: options.store,
+            onSelectElement: options.onSelectElement,
+        });
+        renderComponent(options.host, this.component);
+        const initialState = options.store.getState();
+        for (const element of initialState.elements) {
+            if (isContainerType(element.type)) {
+                options.store.ensureContainerDefaults(element.id);
             }
+        }
+        this.component.syncStage(
+            initialState.elements,
+            initialState.selectedElementId,
+            initialState.canvasWidth,
+            initialState.canvasHeight,
+        );
+        this.unsubscribe = options.store.subscribe(event => {
+            if (event.type !== "state") return;
+            for (const element of event.state.elements) {
+                if (isContainerType(element.type)) {
+                    options.store.ensureContainerDefaults(element.id);
+                }
+            }
+            this.component.syncStage(
+                event.state.elements,
+                event.state.selectedElementId,
+                event.state.canvasWidth,
+                event.state.canvasHeight,
+            );
         });
     }
 
     dispose() {
-        this.viewportEl?.removeEventListener("pointerdown", this.onViewportPointerDown);
-        this.viewportEl?.removeEventListener("pointermove", this.onViewportPointerMove);
-        this.viewportEl?.removeEventListener("pointerup", this.onViewportPointerUp);
-        this.viewportEl?.removeEventListener("pointercancel", this.onViewportPointerUp);
-        this.viewportEl?.removeEventListener("wheel", this.onViewportWheel as any);
         this.unsubscribe?.();
-        this.elementNodes.clear();
-    }
-
-    private initialize(host: HTMLElement) {
-        const viewport = host.createDiv({ cls: "sm-le-stage__viewport" });
-        viewport.addEventListener("pointerdown", this.onViewportPointerDown);
-        viewport.addEventListener("pointermove", this.onViewportPointerMove);
-        viewport.addEventListener("pointerup", this.onViewportPointerUp);
-        viewport.addEventListener("pointercancel", this.onViewportPointerUp);
-        viewport.addEventListener("wheel", this.onViewportWheel, { passive: false });
-
-        const cameraPan = viewport.createDiv({ cls: "sm-le-stage__camera" });
-        const cameraZoom = cameraPan.createDiv({ cls: "sm-le-stage__zoom" });
-        const canvas = cameraZoom.createDiv({ cls: "sm-le-canvas" });
-        canvas.addEventListener("pointerdown", event => {
-            if (event.target === canvas) {
-                this.options.onSelectElement?.(null);
-            }
-        });
-
-        this.viewportEl = viewport;
-        this.cameraPanEl = cameraPan;
-        this.cameraZoomEl = cameraZoom;
-        this.canvasEl = canvas;
-    }
-
-    private syncStage(elements: LayoutElement[], selectedId: string | null, canvasWidth: number, canvasHeight: number) {
-        this.canvasEl.style.width = `${canvasWidth}px`;
-        this.canvasEl.style.height = `${canvasHeight}px`;
-
-        const seen = new Set<string>();
-        for (const element of elements) {
-            if (isContainerType(element.type)) {
-                this.options.store.ensureContainerDefaults(element.id);
-            }
-            seen.add(element.id);
-            let node = this.elementNodes.get(element.id);
-            if (!node) {
-                node = this.createElementNode(element);
-                this.elementNodes.set(element.id, node);
-            }
-            this.syncElementNode(node, element);
-        }
-
-        for (const [id, node] of this.elementNodes.entries()) {
-            if (!seen.has(id)) {
-                node.remove();
-                this.elementNodes.delete(id);
-            }
-        }
-
-        for (const [id, node] of this.elementNodes) {
-            node.classList.toggle("is-selected", id === selectedId);
-        }
-
-        if (!this.hasInitializedCamera) {
-            requestAnimationFrame(() => {
-                if (this.hasInitializedCamera) return;
-                this.centerCamera(canvasWidth, canvasHeight);
-                this.hasInitializedCamera = true;
-            });
-        }
-    }
-
-    private createElementNode(element: LayoutElement) {
-        const node = this.canvasEl.createDiv({ cls: "sm-le-box" });
-        node.dataset.id = element.id;
-
-        const content = node.createDiv({ cls: "sm-le-box__content" });
-        content.dataset.role = "content";
-
-        const updateCursor = (event: PointerEvent) => {
-            const mode = this.resolveInteractionMode(node, event);
-            if (!mode) {
-                node.style.cursor = "";
-                return;
-            }
-            if (mode.type === "resize") {
-                const cursor = mode.corner === "nw" || mode.corner === "se" ? "nwse-resize" : "nesw-resize";
-                node.style.cursor = cursor;
-            } else {
-                node.style.cursor = "move";
-            }
-        };
-
-        node.addEventListener("pointermove", ev => {
-            if (ev.buttons) return;
-            updateCursor(ev);
-        });
-
-        node.addEventListener("pointerleave", () => {
-            if (node.hasClass("is-interacting")) return;
-            node.style.cursor = "";
-        });
-
-        node.addEventListener("pointerdown", ev => {
-            this.options.onSelectElement?.(element.id);
-            const mode = this.resolveInteractionMode(node, ev);
-            if (!mode) return;
-            ev.preventDefault();
-            ev.stopPropagation();
-            node.addClass("is-interacting");
-            const cleanup: InteractionCleanup = () => {
-                node.removeClass("is-interacting");
-                node.style.cursor = "";
-            };
-            if (mode.type === "resize") {
-                this.beginResize(element, ev, mode.corner, cleanup);
-            } else {
-                this.beginMove(element, ev, cleanup);
-            }
-        });
-
-        return node;
-    }
-
-    private syncElementNode(node: HTMLElement, element: LayoutElement) {
-        node.style.left = `${Math.round(element.x)}px`;
-        node.style.top = `${Math.round(element.y)}px`;
-        node.style.width = `${Math.round(element.width)}px`;
-        node.style.height = `${Math.round(element.height)}px`;
-        node.classList.toggle("is-container", isContainerType(element.type));
-        const contentEl = node.querySelector<HTMLElement>('[data-role="content"]');
-        if (contentEl) {
-            renderElementPreview({
-                host: contentEl,
-                element,
-                elements: this.options.store.getState().elements,
-                finalize: target => this.finalizeInlineMutation(target),
-                ensureContainerDefaults: target => this.options.store.ensureContainerDefaults(target.id),
-                applyContainerLayout: (target, opts) => this.options.store.applyContainerLayout(target.id, opts),
-                pushHistory: () => this.options.store.pushHistorySnapshot(),
-                createElement: (type, createOptions) => this.options.store.createElement(type, createOptions),
-            });
-        }
+        this.unsubscribe = null;
+        this.component.destroy();
     }
 
     refreshElement(element: LayoutElement) {
-        const node = this.elementNodes.get(element.id);
-        if (node) {
-            this.syncElementNode(node, element);
-        }
-    }
-
-    private finalizeInlineMutation(element: LayoutElement) {
-        if (isContainerType(element.type)) {
-            this.options.store.applyContainerLayout(element.id, { silent: true });
-        }
-        this.options.store.pushHistorySnapshot();
-    }
-
-    private beginMove(element: LayoutElement, event: PointerEvent, onComplete: InteractionCleanup) {
-        const startX = event.clientX;
-        const startY = event.clientY;
-        const originX = element.x;
-        const originY = element.y;
-        const isContainer = isContainerType(element.type);
-        const parent = element.parentId ? this.options.store.getState().elements.find(el => el.id === element.parentId) : null;
-        const childOrigins = isContainer
-            ? element.children?.map(id => {
-                  const child = this.options.store.getState().elements.find(el => el.id === id);
-                  return child ? { child, x: child.x, y: child.y } : null;
-              }) ?? []
-            : [];
-
-        const onMove = (ev: PointerEvent) => {
-            const dx = ev.clientX - startX;
-            const dy = ev.clientY - startY;
-            let nextX = originX + dx;
-            let nextY = originY + dy;
-            const maxX = Math.max(0, this.options.store.getState().canvasWidth - element.width);
-            const maxY = Math.max(0, this.options.store.getState().canvasHeight - element.height);
-            nextX = clamp(nextX, 0, maxX);
-            nextY = clamp(nextY, 0, maxY);
-            this.options.store.updateElementFrame(element.id, { x: nextX, y: nextY });
-            if (isContainer) {
-                const offsetX = element.x - originX;
-                const offsetY = element.y - originY;
-                for (const entry of childOrigins) {
-                    if (!entry) continue;
-                    entry.child.x = entry.x + offsetX;
-                    entry.child.y = entry.y + offsetY;
-                    this.options.store.updateElementFrame(entry.child.id, {
-                        x: entry.child.x,
-                        y: entry.child.y,
-                    });
-                }
-            }
-            if (parent && isContainerElement(parent)) {
-                this.options.store.applyContainerLayout(parent.id, { silent: true });
-            }
-        };
-
-        const onUp = () => {
-            window.removeEventListener("pointermove", onMove);
-            window.removeEventListener("pointerup", onUp);
-            if (isContainer) {
-                this.options.store.applyContainerLayout(element.id);
-            } else if (parent && isContainerElement(parent)) {
-                this.options.store.applyContainerLayout(parent.id);
-            }
-            this.options.store.pushHistorySnapshot();
-            onComplete();
-        };
-
-        window.addEventListener("pointermove", onMove);
-        window.addEventListener("pointerup", onUp);
-    }
-
-    private beginResize(
-        element: LayoutElement,
-        event: PointerEvent,
-        corner: "nw" | "ne" | "sw" | "se",
-        onComplete: InteractionCleanup,
-    ) {
-        const startX = event.clientX;
-        const startY = event.clientY;
-        const originX = element.x;
-        const originY = element.y;
-        const originW = element.width;
-        const originH = element.height;
-        const isContainer = isContainerType(element.type);
-        const parent = element.parentId ? this.options.store.getState().elements.find(el => el.id === element.parentId) : null;
-
-        const onMove = (ev: PointerEvent) => {
-            const dx = ev.clientX - startX;
-            const dy = ev.clientY - startY;
-            let nextX = element.x;
-            let nextY = element.y;
-            let nextW = element.width;
-            let nextH = element.height;
-
-            if (corner === "nw" || corner === "sw") {
-                const maxLeft = Math.max(0, originX + originW - MIN_ELEMENT_SIZE);
-                const proposedX = clamp(originX + dx, 0, maxLeft);
-                nextX = proposedX;
-                nextW = originW + (originX - proposedX);
-            } else {
-                const maxWidth = Math.max(MIN_ELEMENT_SIZE, this.options.store.getState().canvasWidth - originX);
-                nextW = clamp(originW + dx, MIN_ELEMENT_SIZE, maxWidth);
-            }
-
-            if (corner === "nw" || corner === "ne") {
-                const maxTop = Math.max(0, originY + originH - MIN_ELEMENT_SIZE);
-                const proposedY = clamp(originY + dy, 0, maxTop);
-                nextY = proposedY;
-                nextH = originH + (originY - proposedY);
-            } else {
-                const maxHeight = Math.max(MIN_ELEMENT_SIZE, this.options.store.getState().canvasHeight - originY);
-                nextH = clamp(originH + dy, MIN_ELEMENT_SIZE, maxHeight);
-            }
-
-            this.options.store.updateElementFrame(element.id, {
-                x: nextX,
-                y: nextY,
-                width: nextW,
-                height: nextH,
-            });
-
-            if (isContainer) {
-                this.options.store.applyContainerLayout(element.id, { silent: true });
-            } else if (parent && isContainerElement(parent)) {
-                this.options.store.applyContainerLayout(parent.id, { silent: true });
-            }
-        };
-
-        const onUp = () => {
-            window.removeEventListener("pointermove", onMove);
-            window.removeEventListener("pointerup", onUp);
-            if (isContainer) {
-                this.options.store.applyContainerLayout(element.id);
-            } else if (parent && isContainerElement(parent)) {
-                this.options.store.applyContainerLayout(parent.id);
-            }
-            this.options.store.pushHistorySnapshot();
-            onComplete();
-        };
-
-        window.addEventListener("pointermove", onMove);
-        window.addEventListener("pointerup", onUp);
-    }
-
-    private resolveInteractionMode(
-        el: HTMLElement,
-        event: PointerEvent,
-    ): { type: "move" } | { type: "resize"; corner: "nw" | "ne" | "sw" | "se" } | null {
-        const rect = el.getBoundingClientRect();
-        if (!rect.width || !rect.height) return null;
-        const margin = Math.min(14, rect.width / 2, rect.height / 2);
-        const offsetX = event.clientX - rect.left;
-        const offsetY = event.clientY - rect.top;
-        if (offsetX < 0 || offsetY < 0 || offsetX > rect.width || offsetY > rect.height) return null;
-        const nearLeft = offsetX <= margin;
-        const nearRight = rect.width - offsetX <= margin;
-        const nearTop = offsetY <= margin;
-        const nearBottom = rect.height - offsetY <= margin;
-        if (nearLeft && nearTop) return { type: "resize", corner: "nw" };
-        if (nearRight && nearTop) return { type: "resize", corner: "ne" };
-        if (nearLeft && nearBottom) return { type: "resize", corner: "sw" };
-        if (nearRight && nearBottom) return { type: "resize", corner: "se" };
-        if (nearLeft || nearRight || nearTop || nearBottom) return { type: "move" };
-        return null;
-    }
-
-    private onViewportPointerDown = (event: PointerEvent) => {
-        if (event.button !== 1 && !(event.button === 0 && event.altKey)) return;
-        if (!this.viewportEl) return;
-        event.preventDefault();
-        this.panPointerId = event.pointerId;
-        this.panStartX = event.clientX;
-        this.panStartY = event.clientY;
-        this.panOriginX = this.cameraX;
-        this.panOriginY = this.cameraY;
-        this.viewportEl.setPointerCapture(event.pointerId);
-        this.viewportEl.addClass("is-panning");
-    };
-
-    private onViewportPointerMove = (event: PointerEvent) => {
-        if (this.panPointerId === null) return;
-        if (event.pointerId !== this.panPointerId) return;
-        const dx = event.clientX - this.panStartX;
-        const dy = event.clientY - this.panStartY;
-        this.cameraX = this.panOriginX + dx;
-        this.cameraY = this.panOriginY + dy;
-        this.applyCameraTransform();
-    };
-
-    private onViewportPointerUp = (event: PointerEvent) => {
-        if (this.panPointerId === null) return;
-        if (event.pointerId !== this.panPointerId) return;
-        this.viewportEl?.releasePointerCapture(event.pointerId);
-        this.viewportEl?.removeClass("is-panning");
-        this.panPointerId = null;
-    };
-
-    private onViewportWheel = (event: WheelEvent) => {
-        if (!event.deltaY) return;
-        event.preventDefault();
-        const scaleFactor = event.deltaY < 0 ? 1.1 : 1 / 1.1;
-        const nextScale = clamp(this.cameraScale * scaleFactor, 0.25, 3);
-        if (Math.abs(nextScale - this.cameraScale) < 0.0001) return;
-        const rect = this.viewportEl.getBoundingClientRect();
-        const pointerX = event.clientX - rect.left;
-        const pointerY = event.clientY - rect.top;
-        const worldX = (pointerX - this.cameraX) / this.cameraScale;
-        const worldY = (pointerY - this.cameraY) / this.cameraScale;
-        this.cameraScale = nextScale;
-        this.cameraX = pointerX - worldX * this.cameraScale;
-        this.cameraY = pointerY - worldY * this.cameraScale;
-        this.applyCameraTransform();
-    };
-
-    private applyCameraTransform() {
-        if (!this.cameraPanEl || !this.cameraZoomEl) return;
-        this.cameraPanEl.style.transform = `translate(${Math.round(this.cameraX)}px, ${Math.round(this.cameraY)}px)`;
-        this.cameraZoomEl.style.transform = `scale(${this.cameraScale})`;
-    }
-
-    private centerCamera(canvasWidth: number, canvasHeight: number) {
-        if (!this.viewportEl) return;
-        const rect = this.viewportEl.getBoundingClientRect();
-        if (!rect.width || !rect.height) return;
-        const scaledWidth = canvasWidth * this.cameraScale;
-        const scaledHeight = canvasHeight * this.cameraScale;
-        this.cameraX = Math.round((rect.width - scaledWidth) / 2);
-        this.cameraY = Math.round((rect.height - scaledHeight) / 2);
-        this.applyCameraTransform();
+        this.component.refreshElement(element);
     }
 
     focusElement(element: LayoutElement) {
-        if (!this.viewportEl) return;
-        const rect = this.viewportEl.getBoundingClientRect();
-        if (!rect.width || !rect.height) return;
-        const scale = this.cameraScale || 1;
-        const centerX = element.x + element.width / 2;
-        const centerY = element.y + element.height / 2;
-        this.cameraX = Math.round(rect.width / 2 - centerX * scale);
-        this.cameraY = Math.round(rect.height / 2 - centerY * scale);
-        this.applyCameraTransform();
+        this.component.focusElement(element);
     }
 }

--- a/layout-editor/src/presenters/structure-panel.ts
+++ b/layout-editor/src/presenters/structure-panel.ts
@@ -1,9 +1,12 @@
 // src/presenters/structure-panel.ts
-import { getElementTypeLabel } from "../definitions";
 import { LayoutEditorStore } from "../state/layout-editor-store";
 import { LayoutElement } from "../types";
-import { collectDescendantIds, isContainerElement } from "../utils";
-import { createElementsButton } from "../elements/ui";
+import { isContainerElement } from "../utils";
+import { renderComponent } from "../ui/components/component";
+import {
+    StructureTreeComponent,
+    type StructureTreeState,
+} from "../ui/components/structure-tree";
 import { StageController } from "./stage-controller";
 
 interface StructurePanelOptions {
@@ -14,222 +17,76 @@ interface StructurePanelOptions {
 }
 
 export class StructurePanelPresenter {
-    private rootDropZone: HTMLElement | null = null;
+    private readonly tree: StructureTreeComponent;
     private unsubscribe: (() => void) | null = null;
 
     constructor(private readonly options: StructurePanelOptions) {
+        this.tree = new StructureTreeComponent({
+            onSelect: id => this.handleSelect(id),
+            onReparent: payload => this.handleReparent(payload.elementId, payload.nextParentId),
+            onReorder: payload => this.handleReorder(payload.elementId, payload.targetId, payload.position),
+            onDragStateChange: id => this.options.store.setDraggedElement(id),
+        });
+        renderComponent(options.host, this.tree);
+        const initialState = this.options.store.getState();
+        this.tree.setState(this.createStateSnapshot(initialState.elements, initialState.selectedElementId, initialState.draggedElementId));
         this.unsubscribe = options.store.subscribe(event => {
             if (event.type === "state") {
-                this.render(event.state.elements, event.state.selectedElementId);
+                this.tree.setState(
+                    this.createStateSnapshot(event.state.elements, event.state.selectedElementId, event.state.draggedElementId),
+                );
             }
         });
     }
 
     dispose() {
         this.unsubscribe?.();
-        this.rootDropZone = null;
+        this.unsubscribe = null;
+        this.tree.destroy();
     }
 
-    private render(elements: LayoutElement[], selectedId: string | null) {
-        const host = this.options.host;
-        host.empty();
-        this.rootDropZone = null;
-        if (!elements.length) {
-            host.createDiv({ cls: "sm-le-empty", text: "Noch keine Elemente." });
-            return;
+    private handleSelect(id: string) {
+        this.options.onSelectElement(id);
+        const element = this.options.store.getState().elements.find(el => el.id === id);
+        if (element) {
+            this.options.stage.focusElement(element);
         }
+    }
 
-        const elementById = new Map(elements.map(element => [element.id, element]));
-        const childrenByParent = new Map<string | null, LayoutElement[]>();
+    private handleReparent(elementId: string, nextParentId: string | null) {
+        this.options.store.assignElementToContainer(elementId, nextParentId);
+    }
 
-        for (const element of elements) {
-            const parentExists = element.parentId && elementById.has(element.parentId) ? element.parentId : null;
-            const key = parentExists ?? null;
-            const bucket = childrenByParent.get(key);
-            if (bucket) {
-                bucket.push(element);
-            } else {
-                childrenByParent.set(key, [element]);
-            }
+    private handleReorder(elementId: string, targetId: string, position: "before" | "after") {
+        const state = this.options.store.getState();
+        const dragged = state.elements.find(el => el.id === elementId);
+        const target = state.elements.find(el => el.id === targetId);
+        if (!dragged || !target) return;
+        if (!dragged.parentId || dragged.parentId !== target.parentId) return;
+        const container = state.elements.find(el => el.id === dragged.parentId);
+        if (!container || !isContainerElement(container) || !container.children) return;
+        const currentIndex = container.children.indexOf(elementId);
+        const targetIndex = container.children.indexOf(targetId);
+        if (currentIndex === -1 || targetIndex === -1) return;
+        let destinationIndex = targetIndex + (position === "after" ? 1 : 0);
+        if (destinationIndex > currentIndex) {
+            destinationIndex -= 1;
         }
-
-        for (const element of elements) {
-            if (!isContainerElement(element) || !element.children?.length) continue;
-            const list = childrenByParent.get(element.id);
-            if (!list) continue;
-            const lookup = new Map(list.map(child => [child.id, child]));
-            const ordered: LayoutElement[] = [];
-            for (const childId of element.children) {
-                const child = lookup.get(childId);
-                if (child) {
-                    ordered.push(child);
-                    lookup.delete(childId);
-                }
-            }
-            for (const child of list) {
-                if (lookup.has(child.id)) {
-                    ordered.push(child);
-                    lookup.delete(child.id);
-                }
-            }
-            childrenByParent.set(element.id, ordered);
+        const offset = destinationIndex - currentIndex;
+        if (offset !== 0) {
+            this.options.store.moveChildInContainer(container.id, elementId, offset);
         }
+    }
 
-        const rootDropZone = host.createDiv({
-            cls: "sm-le-structure__root-drop",
-            text: "Ziehe ein Element hierher, um es aus seinem Container zu lösen.",
-        });
-        this.rootDropZone = rootDropZone;
-
-        const canDropToRoot = () => {
-            const draggedId = this.options.store.getState().draggedElementId;
-            if (!draggedId) return false;
-            const dragged = elementById.get(draggedId);
-            if (!dragged) return false;
-            return Boolean(dragged.parentId);
+    private createStateSnapshot(
+        elements: LayoutElement[],
+        selectedId: string | null,
+        draggedId: string | null,
+    ): StructureTreeState {
+        return {
+            elements,
+            selectedId,
+            draggedElementId: draggedId,
         };
-
-        rootDropZone.addEventListener("dragenter", event => {
-            if (!canDropToRoot()) return;
-            event.preventDefault();
-            rootDropZone.addClass("is-active");
-        });
-        rootDropZone.addEventListener("dragover", event => {
-            if (!canDropToRoot()) return;
-            event.preventDefault();
-            if (event.dataTransfer) {
-                event.dataTransfer.dropEffect = "move";
-            }
-            rootDropZone.addClass("is-active");
-        });
-        rootDropZone.addEventListener("dragleave", event => {
-            const related = event.relatedTarget as HTMLElement | null;
-            if (!related || !rootDropZone.contains(related)) {
-                rootDropZone.removeClass("is-active");
-            }
-        });
-        rootDropZone.addEventListener("drop", event => {
-            if (!canDropToRoot()) return;
-            event.preventDefault();
-            event.stopPropagation();
-            rootDropZone.removeClass("is-active");
-            const draggedId = this.options.store.getState().draggedElementId;
-            if (draggedId) {
-                this.options.store.assignElementToContainer(draggedId, null);
-            }
-            this.clearDragState();
-        });
-
-        const renderLevel = (parentId: string | null, container: HTMLElement) => {
-            const children = childrenByParent.get(parentId);
-            if (!children || !children.length) return;
-            const listEl = container.createEl("ul", { cls: "sm-le-structure__list" });
-            for (const child of children) {
-                const itemEl = listEl.createEl("li", { cls: "sm-le-structure__item" });
-                const entry = createElementsButton(itemEl, { label: "" });
-                entry.addClass("sm-le-structure__entry");
-                entry.dataset.id = child.id;
-                if (selectedId === child.id) {
-                    entry.addClass("is-selected");
-                }
-                const name = child.label?.trim() || getElementTypeLabel(child.type);
-                entry.createSpan({ cls: "sm-le-structure__title", text: name });
-                const parentElement = child.parentId ? elementById.get(child.parentId) ?? null : null;
-                const metaParts: string[] = [getElementTypeLabel(child.type)];
-                if (parentElement) {
-                    const parentName = parentElement.label?.trim() || getElementTypeLabel(parentElement.type);
-                    metaParts.push(`Übergeordnet: ${parentName}`);
-                }
-                if (isContainerElement(child)) {
-                    const count = child.children?.length ?? 0;
-                    const label = count === 1 ? "1 Kind" : `${count} Kinder`;
-                    metaParts.push(label);
-                    entry.addClass("sm-le-structure__entry--container");
-                }
-                entry.createSpan({ cls: "sm-le-structure__meta", text: metaParts.join(" • ") });
-                entry.onclick = ev => {
-                    ev.preventDefault();
-                    this.options.onSelectElement(child.id);
-                    this.options.stage.focusElement(child);
-                };
-                entry.draggable = true;
-                entry.addClass("is-draggable");
-                entry.addEventListener("dragstart", dragEvent => {
-                    this.options.store.setDraggedElement(child.id);
-                    dragEvent.dataTransfer?.setData("text/plain", child.id);
-                    if (dragEvent.dataTransfer) {
-                        dragEvent.dataTransfer.effectAllowed = "move";
-                    }
-                });
-                entry.addEventListener("dragend", () => {
-                    this.clearDragState();
-                });
-                if (isContainerElement(child)) {
-                    const canDropHere = () => this.canDropOnContainer(child, elements);
-                    entry.addEventListener("dragenter", dragEvent => {
-                        if (!canDropHere()) return;
-                        dragEvent.preventDefault();
-                        entry.addClass("is-drop-target");
-                    });
-                    entry.addEventListener("dragover", dragEvent => {
-                        if (!canDropHere()) return;
-                        dragEvent.preventDefault();
-                        if (dragEvent.dataTransfer) {
-                            dragEvent.dataTransfer.dropEffect = "move";
-                        }
-                        entry.addClass("is-drop-target");
-                    });
-                    entry.addEventListener("dragleave", dragEvent => {
-                        const related = dragEvent.relatedTarget as HTMLElement | null;
-                        if (!related || !entry.contains(related)) {
-                            entry.removeClass("is-drop-target");
-                        }
-                    });
-                    entry.addEventListener("drop", dragEvent => {
-                        if (!canDropHere()) return;
-                        dragEvent.preventDefault();
-                        dragEvent.stopPropagation();
-                        const draggedId = this.options.store.getState().draggedElementId;
-                        if (draggedId) {
-                            this.options.store.assignElementToContainer(draggedId, child.id);
-                        }
-                        this.clearDragState();
-                    });
-                }
-                renderLevel(child.id, itemEl);
-            }
-        };
-
-        renderLevel(null, host);
-    }
-
-    private canDropOnContainer(container: LayoutElement, elements: LayoutElement[]) {
-        const draggedId = this.options.store.getState().draggedElementId;
-        if (!draggedId) return false;
-        if (!isContainerElement(container)) return false;
-        const dragged = elements.find(el => el.id === draggedId);
-        if (!dragged) return false;
-        if (dragged.id === container.id) return false;
-        if (dragged.parentId === container.id) return false;
-        if (isContainerElement(dragged)) {
-            const descendants = collectDescendantIds(dragged, elements);
-            if (descendants.has(container.id)) return false;
-        }
-        let cursor = container.parentId ? elements.find(el => el.id === container.parentId) : null;
-        while (cursor) {
-            if (cursor.id === dragged.id) return false;
-            cursor = cursor.parentId ? elements.find(el => el.id === cursor.parentId) : null;
-        }
-        return true;
-    }
-
-    private clearDragState() {
-        this.options.store.setDraggedElement(null);
-        const host = this.options.host;
-        const targets = Array.from(host.querySelectorAll<HTMLElement>(".sm-le-structure__entry.is-drop-target"));
-        for (const target of targets) {
-            target.removeClass("is-drop-target");
-        }
-        this.rootDropZone?.removeClass("is-active");
     }
 }

--- a/layout-editor/src/ui/components/component.ts
+++ b/layout-editor/src/ui/components/component.ts
@@ -1,0 +1,109 @@
+const HOST_COMPONENT_KEY = Symbol("sm-ui-component");
+
+export type UIComponentHost<T extends HTMLElement = HTMLElement> = T & {
+    [HOST_COMPONENT_KEY]?: UIComponent<T>;
+};
+
+export abstract class UIComponent<T extends HTMLElement = HTMLElement> {
+    private cleanups: Array<() => void> = [];
+    private mountedHost: UIComponentHost<T> | null = null;
+
+    mount(host: T): void {
+        if (this.mountedHost && this.mountedHost !== host) {
+            this.destroy();
+        }
+        const typedHost = host as UIComponentHost<T>;
+        if (typedHost[HOST_COMPONENT_KEY] && typedHost[HOST_COMPONENT_KEY] !== this) {
+            typedHost[HOST_COMPONENT_KEY]!.destroy();
+        }
+        this.mountedHost = typedHost;
+        typedHost[HOST_COMPONENT_KEY] = this;
+        this.onMount(host);
+    }
+
+    destroy(): void {
+        if (!this.mountedHost) return;
+        try {
+            this.onDestroy();
+        } finally {
+            for (const cleanup of this.cleanups.splice(0)) {
+                try {
+                    cleanup();
+                } catch (error) {
+                    console.error("UIComponent cleanup failed", error);
+                }
+            }
+            delete this.mountedHost[HOST_COMPONENT_KEY];
+            this.mountedHost = null;
+        }
+    }
+
+    protected abstract onMount(host: T): void;
+    protected onDestroy(): void {}
+
+    protected requireHost(): T {
+        if (!this.mountedHost) {
+            throw new Error("Component is not mounted");
+        }
+        return this.mountedHost as T;
+    }
+
+    protected registerCleanup(cleanup: () => void): void {
+        this.cleanups.push(cleanup);
+    }
+
+    protected listen(
+        target: EventTarget,
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+    ): () => void {
+        target.addEventListener(type, listener, options);
+        let active = true;
+        const cleanup = () => {
+            if (!active) return;
+            active = false;
+            target.removeEventListener(type, listener, options);
+        };
+        this.registerCleanup(cleanup);
+        return cleanup;
+    }
+
+    protected observeMutations(target: Node, options: MutationObserverInit, callback: MutationCallback): MutationObserver {
+        const observer = new MutationObserver(callback);
+        observer.observe(target, options);
+        this.registerCleanup(() => observer.disconnect());
+        return observer;
+    }
+
+    protected observeResize(target: Element, callback: ResizeObserverCallback): ResizeObserver {
+        const observer = new ResizeObserver(callback);
+        observer.observe(target);
+        this.registerCleanup(() => observer.disconnect());
+        return observer;
+    }
+
+    protected observeIntersections(target: Element, callback: IntersectionObserverCallback, options?: IntersectionObserverInit): IntersectionObserver {
+        const observer = new IntersectionObserver(callback, options);
+        observer.observe(target);
+        this.registerCleanup(() => observer.disconnect());
+        return observer;
+    }
+
+    protected clearHost(host?: HTMLElement): void {
+        const node = host ?? this.requireHost();
+        const anyNode = node as any;
+        if (typeof anyNode.empty === "function") {
+            anyNode.empty();
+            return;
+        }
+        while (node.firstChild) {
+            node.removeChild(node.firstChild);
+        }
+    }
+}
+
+export function renderComponent<T extends HTMLElement, C extends UIComponent<T>>(host: T, component: C): C {
+    component.mount(host);
+    return component;
+}

--- a/layout-editor/src/ui/components/editor-shell.ts
+++ b/layout-editor/src/ui/components/editor-shell.ts
@@ -1,0 +1,190 @@
+import { clamp } from "../../utils";
+import { UIComponent } from "./component";
+
+export interface PanelSizeOptions {
+    structureWidth: number;
+    inspectorWidth: number;
+}
+
+interface EditorShellComponentOptions {
+    minPanelWidth: number;
+    minStageWidth: number;
+    resizerSize: number;
+    initialSizes: PanelSizeOptions;
+    onResizePanels?(sizes: PanelSizeOptions): void;
+}
+
+export class EditorShellComponent extends UIComponent<HTMLElement> {
+    private headerHost!: HTMLElement;
+    private bodyEl!: HTMLElement;
+    private structurePanelEl!: HTMLElement;
+    private inspectorPanelEl!: HTMLElement;
+    private structureHost!: HTMLElement;
+    private stageHost!: HTMLElement;
+    private inspectorHost!: HTMLElement;
+    private structureResizer!: HTMLElement;
+    private inspectorResizer!: HTMLElement;
+
+    private structureWidth: number;
+    private inspectorWidth: number;
+
+    constructor(private readonly options: EditorShellComponentOptions) {
+        super();
+        this.structureWidth = options.initialSizes.structureWidth;
+        this.inspectorWidth = options.initialSizes.inspectorWidth;
+    }
+
+    protected onMount(host: HTMLElement): void {
+        this.clearHost(host);
+
+        this.headerHost = host.createDiv({ cls: "sm-le-wrapper" });
+
+        this.bodyEl = host.createDiv({ cls: "sm-le-body" });
+
+        this.structurePanelEl = this.bodyEl.createDiv({ cls: "sm-le-panel sm-le-panel--structure" });
+        this.structurePanelEl.createEl("h3", { text: "Struktur" });
+        this.structureHost = this.structurePanelEl.createDiv({ cls: "sm-le-structure" });
+
+        this.structureResizer = this.bodyEl.createDiv({ cls: "sm-le-resizer sm-le-resizer--structure" });
+        this.structureResizer.setAttr("role", "separator");
+        this.structureResizer.setAttr("aria-orientation", "vertical");
+        this.structureResizer.tabIndex = 0;
+        this.listen(this.structureResizer, "pointerdown", event => this.beginResize(event as PointerEvent, "structure"));
+
+        const stageWrapper = this.bodyEl.createDiv({ cls: "sm-le-stage" });
+        this.stageHost = stageWrapper;
+
+        this.inspectorResizer = this.bodyEl.createDiv({ cls: "sm-le-resizer sm-le-resizer--inspector" });
+        this.inspectorResizer.setAttr("role", "separator");
+        this.inspectorResizer.setAttr("aria-orientation", "vertical");
+        this.inspectorResizer.tabIndex = 0;
+        this.listen(this.inspectorResizer, "pointerdown", event => this.beginResize(event as PointerEvent, "inspector"));
+
+        this.inspectorPanelEl = this.bodyEl.createDiv({ cls: "sm-le-panel sm-le-panel--inspector" });
+        this.inspectorPanelEl.createEl("h3", { text: "Eigenschaften" });
+        this.inspectorHost = this.inspectorPanelEl.createDiv({ cls: "sm-le-inspector" });
+
+        this.applyPanelSizes();
+    }
+
+    protected onDestroy(): void {
+        this.headerHost = null as any;
+        this.bodyEl = null as any;
+        this.structurePanelEl = null as any;
+        this.inspectorPanelEl = null as any;
+        this.structureResizer = null as any;
+        this.inspectorResizer = null as any;
+        this.structureHost = null as any;
+        this.stageHost = null as any;
+        this.inspectorHost = null as any;
+    }
+
+    getHeaderHost(): HTMLElement {
+        return this.headerHost;
+    }
+
+    getStructureHost(): HTMLElement {
+        return this.structureHost;
+    }
+
+    getStageHost(): HTMLElement {
+        return this.stageHost;
+    }
+
+    getInspectorHost(): HTMLElement {
+        return this.inspectorHost;
+    }
+
+    getStructurePanel(): HTMLElement {
+        return this.structurePanelEl;
+    }
+
+    getInspectorPanel(): HTMLElement {
+        return this.inspectorPanelEl;
+    }
+
+    setPanelSizes(sizes: PanelSizeOptions): void {
+        this.structureWidth = sizes.structureWidth;
+        this.inspectorWidth = sizes.inspectorWidth;
+        this.applyPanelSizes();
+    }
+
+    private beginResize(event: PointerEvent, target: "structure" | "inspector") {
+        if (event.button !== 0) return;
+        if (!this.bodyEl) return;
+        event.preventDefault();
+        const handle = event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+        const pointerId = event.pointerId;
+        const otherWidth = target === "structure" ? this.inspectorWidth : this.structureWidth;
+
+        handle?.setPointerCapture(pointerId);
+        handle?.addClass("is-active");
+
+        const onPointerMove = (ev: PointerEvent) => {
+            if (ev.pointerId !== pointerId) return;
+            const bodyRect = this.bodyEl.getBoundingClientRect();
+            const maxWidth = Math.max(
+                this.options.minPanelWidth,
+                bodyRect.width - otherWidth - this.options.resizerSize * 2 - this.options.minStageWidth,
+            );
+            let proposedWidth: number;
+            if (target === "structure") {
+                proposedWidth = ev.clientX - bodyRect.left - this.options.resizerSize / 2;
+                const next = clamp(Math.round(proposedWidth), this.options.minPanelWidth, maxWidth);
+                if (next !== this.structureWidth) {
+                    this.structureWidth = next;
+                    this.applyPanelSizes();
+                    this.options.onResizePanels?.({
+                        structureWidth: this.structureWidth,
+                        inspectorWidth: this.inspectorWidth,
+                    });
+                }
+            } else {
+                proposedWidth = bodyRect.right - ev.clientX - this.options.resizerSize / 2;
+                const next = clamp(Math.round(proposedWidth), this.options.minPanelWidth, maxWidth);
+                if (next !== this.inspectorWidth) {
+                    this.inspectorWidth = next;
+                    this.applyPanelSizes();
+                    this.options.onResizePanels?.({
+                        structureWidth: this.structureWidth,
+                        inspectorWidth: this.inspectorWidth,
+                    });
+                }
+            }
+        };
+
+        const moveTarget: EventTarget = handle ?? window;
+        const stopMove = this.listen(moveTarget, "pointermove", onPointerMove as EventListener);
+        const stopUp = this.listen(moveTarget, "pointerup", (ev: PointerEvent) => {
+            if (ev.pointerId !== pointerId) return;
+            stopMove();
+            stopUp();
+            handle?.releasePointerCapture(pointerId);
+            handle?.removeClass("is-active");
+            this.options.onResizePanels?.({
+                structureWidth: this.structureWidth,
+                inspectorWidth: this.inspectorWidth,
+            });
+        });
+
+        this.registerCleanup(() => {
+            stopMove();
+            stopUp();
+            handle?.releasePointerCapture(pointerId);
+            handle?.removeClass("is-active");
+        });
+    }
+
+    private applyPanelSizes() {
+        if (this.structurePanelEl) {
+            const width = Math.max(this.options.minPanelWidth, Math.round(this.structureWidth));
+            this.structurePanelEl.style.flex = `0 0 ${width}px`;
+            this.structurePanelEl.style.width = `${width}px`;
+        }
+        if (this.inspectorPanelEl) {
+            const width = Math.max(this.options.minPanelWidth, Math.round(this.inspectorWidth));
+            this.inspectorPanelEl.style.flex = `0 0 ${width}px`;
+            this.inspectorPanelEl.style.width = `${width}px`;
+        }
+    }
+}

--- a/layout-editor/src/ui/components/primitives.ts
+++ b/layout-editor/src/ui/components/primitives.ts
@@ -1,0 +1,178 @@
+import {
+    createElementsButton,
+    createElementsField,
+    createElementsStack,
+    createElementsStatus,
+    type ElementsButtonOptions,
+    type ElementsFieldOptions,
+    type ElementsFieldResult,
+    type ElementsStackOptions,
+    type ElementsStatusOptions,
+} from "../../elements/ui";
+import { UIComponent } from "./component";
+
+export interface ButtonComponentOptions extends Omit<ElementsButtonOptions, "onClick"> {
+    onClick?: (event: MouseEvent) => void;
+}
+
+export class ButtonComponent extends UIComponent<HTMLElement> {
+    private buttonEl: HTMLButtonElement | null = null;
+
+    constructor(private options: ButtonComponentOptions) {
+        super();
+    }
+
+    protected onMount(host: HTMLElement): void {
+        this.clearHost(host);
+        const { onClick, ...rest } = this.options;
+        const button = createElementsButton(host, rest as ElementsButtonOptions);
+        this.buttonEl = button;
+        const handler = (event: MouseEvent) => {
+            this.options.onClick?.(event);
+        };
+        this.listen(button, "click", handler as EventListener);
+        if (onClick) {
+            this.options.onClick = onClick;
+        }
+    }
+
+    protected onDestroy(): void {
+        this.buttonEl = null;
+    }
+
+    get element(): HTMLButtonElement {
+        if (!this.buttonEl) {
+            throw new Error("ButtonComponent is not mounted");
+        }
+        return this.buttonEl;
+    }
+
+    setDisabled(disabled: boolean): void {
+        const el = this.buttonEl;
+        if (!el) return;
+        el.disabled = disabled;
+    }
+
+    setLabel(label: string): void {
+        this.options.label = label;
+        const el = this.buttonEl;
+        if (!el) return;
+        if (this.options.icon) {
+            const labelSpan = el.querySelector<HTMLElement>(".sm-elements-button__label");
+            if (labelSpan) {
+                labelSpan.setText(label);
+            }
+        } else {
+            el.setText(label);
+        }
+    }
+
+    setOnClick(onClick: ((event: MouseEvent) => void) | undefined): void {
+        this.options.onClick = onClick;
+    }
+}
+
+export class FieldComponent extends UIComponent<HTMLElement> {
+    private result: ElementsFieldResult | null = null;
+
+    constructor(private options: ElementsFieldOptions) {
+        super();
+    }
+
+    protected onMount(host: HTMLElement): void {
+        this.clearHost(host);
+        this.result = createElementsField(host, this.options);
+    }
+
+    protected onDestroy(): void {
+        this.result = null;
+    }
+
+    get field(): ElementsFieldResult {
+        if (!this.result) {
+            throw new Error("FieldComponent is not mounted");
+        }
+        return this.result;
+    }
+
+    setDescription(description: string | null): void {
+        if (!this.result) return;
+        this.options.description = description ?? undefined;
+        if (description) {
+            if (!this.result.descriptionEl) {
+                this.result.descriptionEl = this.result.fieldEl.createDiv({
+                    cls: "sm-elements-field__description",
+                    text: description,
+                });
+            } else {
+                this.result.descriptionEl.setText(description);
+            }
+        } else if (this.result.descriptionEl) {
+            this.result.descriptionEl.remove();
+            this.result.descriptionEl = undefined;
+        }
+    }
+}
+
+export class StackComponent extends UIComponent<HTMLElement> {
+    private stackEl: HTMLElement | null = null;
+
+    constructor(private options: ElementsStackOptions = {}) {
+        super();
+    }
+
+    protected onMount(host: HTMLElement): void {
+        this.clearHost(host);
+        this.stackEl = createElementsStack(host, this.options);
+    }
+
+    protected onDestroy(): void {
+        this.stackEl = null;
+    }
+
+    get element(): HTMLElement {
+        if (!this.stackEl) {
+            throw new Error("StackComponent is not mounted");
+        }
+        return this.stackEl;
+    }
+}
+
+export class StatusComponent extends UIComponent<HTMLElement> {
+    private statusEl: HTMLElement | null = null;
+
+    constructor(private options: ElementsStatusOptions) {
+        super();
+    }
+
+    protected onMount(host: HTMLElement): void {
+        this.clearHost(host);
+        this.statusEl = createElementsStatus(host, this.options);
+    }
+
+    protected onDestroy(): void {
+        this.statusEl = null;
+    }
+
+    get element(): HTMLElement {
+        if (!this.statusEl) {
+            throw new Error("StatusComponent is not mounted");
+        }
+        return this.statusEl;
+    }
+
+    setText(text: string): void {
+        this.options.text = text;
+        this.statusEl?.setText(text);
+    }
+
+    setTone(tone: ElementsStatusOptions["tone"]): void {
+        const el = this.statusEl;
+        if (!el) return;
+        if (this.options.tone) {
+            el.removeClass(`sm-elements-status--${this.options.tone}`);
+        }
+        this.options.tone = tone;
+        el.addClass(`sm-elements-status--${tone}`);
+    }
+}

--- a/layout-editor/src/ui/components/stage.ts
+++ b/layout-editor/src/ui/components/stage.ts
@@ -1,0 +1,418 @@
+import { MIN_ELEMENT_SIZE, isContainerType } from "../../definitions";
+import { renderElementPreview } from "../../element-preview";
+import { LayoutEditorStore } from "../../state/layout-editor-store";
+import { LayoutElement } from "../../types";
+import { clamp, isContainerElement } from "../../utils";
+import { UIComponent } from "./component";
+
+export interface StageComponentOptions {
+    store: LayoutEditorStore;
+    onSelectElement?(id: string | null): void;
+}
+
+interface InteractionCleanup {
+    (): void;
+}
+
+export class StageComponent extends UIComponent<HTMLElement> {
+    private readonly elementNodes = new Map<string, HTMLElement>();
+    private canvasEl!: HTMLElement;
+    private viewportEl!: HTMLElement;
+    private cameraPanEl!: HTMLElement;
+    private cameraZoomEl!: HTMLElement;
+
+    private cameraScale = 1;
+    private cameraX = 0;
+    private cameraY = 0;
+    private panPointerId: number | null = null;
+    private panStartX = 0;
+    private panStartY = 0;
+    private panOriginX = 0;
+    private panOriginY = 0;
+    private hasInitializedCamera = false;
+
+    constructor(private readonly options: StageComponentOptions) {
+        super();
+    }
+
+    protected onMount(host: HTMLElement): void {
+        this.clearHost(host);
+
+        const viewport = host.createDiv({ cls: "sm-le-stage__viewport" });
+        this.listen(viewport, "pointerdown", this.onViewportPointerDown);
+        this.listen(viewport, "pointermove", this.onViewportPointerMove);
+        this.listen(viewport, "pointerup", this.onViewportPointerUp);
+        this.listen(viewport, "pointercancel", this.onViewportPointerUp);
+        this.listen(viewport, "wheel", this.onViewportWheel as EventListener, { passive: false });
+
+        const cameraPan = viewport.createDiv({ cls: "sm-le-stage__camera" });
+        const cameraZoom = cameraPan.createDiv({ cls: "sm-le-stage__zoom" });
+        const canvas = cameraZoom.createDiv({ cls: "sm-le-canvas" });
+        this.listen(canvas, "pointerdown", event => {
+            if (event.target === canvas) {
+                this.options.onSelectElement?.(null);
+            }
+        });
+
+        this.viewportEl = viewport;
+        this.cameraPanEl = cameraPan;
+        this.cameraZoomEl = cameraZoom;
+        this.canvasEl = canvas;
+        this.hasInitializedCamera = false;
+    }
+
+    protected onDestroy(): void {
+        this.elementNodes.clear();
+        this.clearHost();
+    }
+
+    syncStage(elements: LayoutElement[], selectedId: string | null, canvasWidth: number, canvasHeight: number) {
+        if (!this.canvasEl) return;
+        this.canvasEl.style.width = `${canvasWidth}px`;
+        this.canvasEl.style.height = `${canvasHeight}px`;
+
+        const seen = new Set<string>();
+        for (const element of elements) {
+            seen.add(element.id);
+            let node = this.elementNodes.get(element.id);
+            if (!node) {
+                node = this.createElementNode(element);
+                this.elementNodes.set(element.id, node);
+            }
+            this.syncElementNode(node, element);
+        }
+
+        for (const [id, node] of this.elementNodes.entries()) {
+            if (!seen.has(id)) {
+                node.remove();
+                this.elementNodes.delete(id);
+            }
+        }
+
+        for (const [id, node] of this.elementNodes) {
+            node.classList.toggle("is-selected", id === selectedId);
+        }
+
+        if (!this.hasInitializedCamera) {
+            requestAnimationFrame(() => {
+                if (this.hasInitializedCamera) return;
+                this.centerCamera(canvasWidth, canvasHeight);
+                this.hasInitializedCamera = true;
+            });
+        }
+    }
+
+    refreshElement(element: LayoutElement) {
+        const node = this.elementNodes.get(element.id);
+        if (node) {
+            this.syncElementNode(node, element);
+        }
+    }
+
+    focusElement(element: LayoutElement) {
+        if (!this.viewportEl) return;
+        const rect = this.viewportEl.getBoundingClientRect();
+        if (!rect.width || !rect.height) return;
+        const scale = this.cameraScale || 1;
+        const centerX = element.x + element.width / 2;
+        const centerY = element.y + element.height / 2;
+        this.cameraX = Math.round(rect.width / 2 - centerX * scale);
+        this.cameraY = Math.round(rect.height / 2 - centerY * scale);
+        this.applyCameraTransform();
+    }
+
+    private createElementNode(element: LayoutElement) {
+        const node = this.canvasEl.createDiv({ cls: "sm-le-box" });
+        node.dataset.id = element.id;
+
+        const content = node.createDiv({ cls: "sm-le-box__content" });
+        content.dataset.role = "content";
+
+        const updateCursor = (event: PointerEvent) => {
+            const mode = this.resolveInteractionMode(node, event);
+            if (!mode) {
+                node.style.cursor = "";
+                return;
+            }
+            if (mode.type === "resize") {
+                const cursor = mode.corner === "nw" || mode.corner === "se" ? "nwse-resize" : "nesw-resize";
+                node.style.cursor = cursor;
+            } else {
+                node.style.cursor = "move";
+            }
+        };
+
+        this.listen(node, "pointermove", ev => {
+            if (ev.buttons) return;
+            updateCursor(ev as PointerEvent);
+        });
+
+        this.listen(node, "pointerleave", () => {
+            if (node.hasClass("is-interacting")) return;
+            node.style.cursor = "";
+        });
+
+        this.listen(node, "pointerdown", ev => {
+            const event = ev as PointerEvent;
+            this.options.onSelectElement?.(element.id);
+            const mode = this.resolveInteractionMode(node, event);
+            if (!mode) return;
+            event.preventDefault();
+            event.stopPropagation();
+            node.addClass("is-interacting");
+            const cleanup: InteractionCleanup = () => {
+                node.removeClass("is-interacting");
+                node.style.cursor = "";
+            };
+            if (mode.type === "resize") {
+                this.beginResize(element, event, mode.corner, cleanup);
+            } else {
+                this.beginMove(element, event, cleanup);
+            }
+        });
+
+        return node;
+    }
+
+    private syncElementNode(node: HTMLElement, element: LayoutElement) {
+        node.style.left = `${Math.round(element.x)}px`;
+        node.style.top = `${Math.round(element.y)}px`;
+        node.style.width = `${Math.round(element.width)}px`;
+        node.style.height = `${Math.round(element.height)}px`;
+        node.classList.toggle("is-container", isContainerType(element.type));
+        const contentEl = node.querySelector<HTMLElement>('[data-role="content"]');
+        if (contentEl) {
+            renderElementPreview({
+                host: contentEl,
+                element,
+                elements: this.options.store.getState().elements,
+                finalize: target => this.finalizeInlineMutation(target),
+                ensureContainerDefaults: target => this.options.store.ensureContainerDefaults(target.id),
+                applyContainerLayout: (target, opts) => this.options.store.applyContainerLayout(target.id, opts),
+                pushHistory: () => this.options.store.pushHistorySnapshot(),
+                createElement: (type, createOptions) => this.options.store.createElement(type, createOptions),
+            });
+        }
+    }
+
+    private finalizeInlineMutation(element: LayoutElement) {
+        if (isContainerType(element.type)) {
+            this.options.store.applyContainerLayout(element.id, { silent: true });
+        }
+        this.options.store.pushHistorySnapshot();
+    }
+
+    private beginMove(element: LayoutElement, event: PointerEvent, onComplete: InteractionCleanup) {
+        const startX = event.clientX;
+        const startY = event.clientY;
+        const originX = element.x;
+        const originY = element.y;
+        const isContainer = isContainerType(element.type);
+        const parent = element.parentId ? this.options.store.getState().elements.find(el => el.id === element.parentId) : null;
+        const childOrigins = isContainer
+            ? element.children?.map(id => {
+                  const child = this.options.store.getState().elements.find(el => el.id === id);
+                  return child ? { child, x: child.x, y: child.y } : null;
+              }) ?? []
+            : [];
+
+        const onMove = (ev: PointerEvent) => {
+            const dx = ev.clientX - startX;
+            const dy = ev.clientY - startY;
+            let nextX = originX + dx;
+            let nextY = originY + dy;
+            const maxX = Math.max(0, this.options.store.getState().canvasWidth - element.width);
+            const maxY = Math.max(0, this.options.store.getState().canvasHeight - element.height);
+            nextX = clamp(nextX, 0, maxX);
+            nextY = clamp(nextY, 0, maxY);
+            this.options.store.updateElementFrame(element.id, { x: nextX, y: nextY });
+            if (isContainer) {
+                const offsetX = element.x - originX;
+                const offsetY = element.y - originY;
+                for (const entry of childOrigins) {
+                    if (!entry) continue;
+                    entry.child.x = entry.x + offsetX;
+                    entry.child.y = entry.y + offsetY;
+                    this.options.store.updateElementFrame(entry.child.id, {
+                        x: entry.child.x,
+                        y: entry.child.y,
+                    });
+                }
+            }
+            if (parent && isContainerElement(parent)) {
+                this.options.store.applyContainerLayout(parent.id, { silent: true });
+            }
+        };
+
+        const stopMove = this.listen(window, "pointermove", onMove as EventListener);
+        const stopUp = this.listen(window, "pointerup", () => {
+            stopMove();
+            stopUp();
+            if (isContainer) {
+                this.options.store.applyContainerLayout(element.id);
+            } else if (parent && isContainerElement(parent)) {
+                this.options.store.applyContainerLayout(parent.id);
+            }
+            this.options.store.pushHistorySnapshot();
+            onComplete();
+        });
+    }
+
+    private beginResize(
+        element: LayoutElement,
+        event: PointerEvent,
+        corner: "nw" | "ne" | "sw" | "se",
+        onComplete: InteractionCleanup,
+    ) {
+        const startX = event.clientX;
+        const startY = event.clientY;
+        const originX = element.x;
+        const originY = element.y;
+        const originW = element.width;
+        const originH = element.height;
+        const isContainer = isContainerType(element.type);
+        const parent = element.parentId ? this.options.store.getState().elements.find(el => el.id === element.parentId) : null;
+
+        const onMove = (ev: PointerEvent) => {
+            const dx = ev.clientX - startX;
+            const dy = ev.clientY - startY;
+            let nextX = element.x;
+            let nextY = element.y;
+            let nextW = element.width;
+            let nextH = element.height;
+
+            if (corner === "nw" || corner === "sw") {
+                const maxLeft = Math.max(0, originX + originW - MIN_ELEMENT_SIZE);
+                const proposedX = clamp(originX + dx, 0, maxLeft);
+                nextX = proposedX;
+                nextW = originW + (originX - proposedX);
+            } else {
+                const maxWidth = Math.max(MIN_ELEMENT_SIZE, this.options.store.getState().canvasWidth - originX);
+                nextW = clamp(originW + dx, MIN_ELEMENT_SIZE, maxWidth);
+            }
+
+            if (corner === "nw" || corner === "ne") {
+                const maxTop = Math.max(0, originY + originH - MIN_ELEMENT_SIZE);
+                const proposedY = clamp(originY + dy, 0, maxTop);
+                nextY = proposedY;
+                nextH = originH + (originY - proposedY);
+            } else {
+                const maxHeight = Math.max(MIN_ELEMENT_SIZE, this.options.store.getState().canvasHeight - originY);
+                nextH = clamp(originH + dy, MIN_ELEMENT_SIZE, maxHeight);
+            }
+
+            this.options.store.updateElementFrame(element.id, {
+                x: nextX,
+                y: nextY,
+                width: nextW,
+                height: nextH,
+            });
+
+            if (isContainer) {
+                this.options.store.applyContainerLayout(element.id, { silent: true });
+            } else if (parent && isContainerElement(parent)) {
+                this.options.store.applyContainerLayout(parent.id, { silent: true });
+            }
+        };
+
+        const stopMove = this.listen(window, "pointermove", onMove as EventListener);
+        const stopUp = this.listen(window, "pointerup", () => {
+            stopMove();
+            stopUp();
+            if (isContainer) {
+                this.options.store.applyContainerLayout(element.id);
+            } else if (parent && isContainerElement(parent)) {
+                this.options.store.applyContainerLayout(parent.id);
+            }
+            this.options.store.pushHistorySnapshot();
+            onComplete();
+        });
+    }
+
+    private resolveInteractionMode(
+        el: HTMLElement,
+        event: PointerEvent,
+    ): { type: "move" } | { type: "resize"; corner: "nw" | "ne" | "sw" | "se" } | null {
+        const rect = el.getBoundingClientRect();
+        if (!rect.width || !rect.height) return null;
+        const margin = Math.min(14, rect.width / 2, rect.height / 2);
+        const offsetX = event.clientX - rect.left;
+        const offsetY = event.clientY - rect.top;
+        if (offsetX < 0 || offsetY < 0 || offsetX > rect.width || offsetY > rect.height) return null;
+        const nearLeft = offsetX <= margin;
+        const nearRight = rect.width - offsetX <= margin;
+        const nearTop = offsetY <= margin;
+        const nearBottom = rect.height - offsetY <= margin;
+        if (nearLeft && nearTop) return { type: "resize", corner: "nw" };
+        if (nearRight && nearTop) return { type: "resize", corner: "ne" };
+        if (nearLeft && nearBottom) return { type: "resize", corner: "sw" };
+        if (nearRight && nearBottom) return { type: "resize", corner: "se" };
+        if (nearLeft || nearRight || nearTop || nearBottom) return { type: "move" };
+        return null;
+    }
+
+    private onViewportPointerDown = (event: PointerEvent) => {
+        if (event.button !== 1 && !(event.button === 0 && event.altKey)) return;
+        if (!this.viewportEl) return;
+        event.preventDefault();
+        this.panPointerId = event.pointerId;
+        this.panStartX = event.clientX;
+        this.panStartY = event.clientY;
+        this.panOriginX = this.cameraX;
+        this.panOriginY = this.cameraY;
+        this.viewportEl.setPointerCapture(event.pointerId);
+        this.viewportEl.addClass("is-panning");
+    };
+
+    private onViewportPointerMove = (event: PointerEvent) => {
+        if (this.panPointerId === null) return;
+        if (event.pointerId !== this.panPointerId) return;
+        const dx = event.clientX - this.panStartX;
+        const dy = event.clientY - this.panStartY;
+        this.cameraX = this.panOriginX + dx;
+        this.cameraY = this.panOriginY + dy;
+        this.applyCameraTransform();
+    };
+
+    private onViewportPointerUp = (event: PointerEvent) => {
+        if (this.panPointerId === null) return;
+        if (event.pointerId !== this.panPointerId) return;
+        this.viewportEl?.releasePointerCapture(event.pointerId);
+        this.viewportEl?.removeClass("is-panning");
+        this.panPointerId = null;
+    };
+
+    private onViewportWheel = (event: WheelEvent) => {
+        if (!event.deltaY) return;
+        event.preventDefault();
+        const scaleFactor = event.deltaY < 0 ? 1.1 : 1 / 1.1;
+        const nextScale = clamp(this.cameraScale * scaleFactor, 0.25, 3);
+        if (Math.abs(nextScale - this.cameraScale) < 0.0001) return;
+        const rect = this.viewportEl.getBoundingClientRect();
+        const pointerX = event.clientX - rect.left;
+        const pointerY = event.clientY - rect.top;
+        const worldX = (pointerX - this.cameraX) / this.cameraScale;
+        const worldY = (pointerY - this.cameraY) / this.cameraScale;
+        this.cameraScale = nextScale;
+        this.cameraX = pointerX - worldX * this.cameraScale;
+        this.cameraY = pointerY - worldY * this.cameraScale;
+        this.applyCameraTransform();
+    };
+
+    private applyCameraTransform() {
+        if (!this.cameraPanEl || !this.cameraZoomEl) return;
+        this.cameraPanEl.style.transform = `translate(${Math.round(this.cameraX)}px, ${Math.round(this.cameraY)}px)`;
+        this.cameraZoomEl.style.transform = `scale(${this.cameraScale})`;
+    }
+
+    private centerCamera(canvasWidth: number, canvasHeight: number) {
+        if (!this.viewportEl) return;
+        const rect = this.viewportEl.getBoundingClientRect();
+        if (!rect.width || !rect.height) return;
+        const scaledWidth = canvasWidth * this.cameraScale;
+        const scaledHeight = canvasHeight * this.cameraScale;
+        this.cameraX = Math.round((rect.width - scaledWidth) / 2);
+        this.cameraY = Math.round((rect.height - scaledHeight) / 2);
+        this.applyCameraTransform();
+    }
+}

--- a/layout-editor/src/ui/components/structure-tree.ts
+++ b/layout-editor/src/ui/components/structure-tree.ts
@@ -1,0 +1,367 @@
+import { getElementTypeLabel } from "../../definitions";
+import { LayoutElement } from "../../types";
+import { collectDescendantIds, isContainerElement } from "../../utils";
+import { UIComponent } from "./component";
+
+export interface StructureTreeComponentOptions {
+    onSelect?(id: string): void;
+    onReparent?(payload: { elementId: string; nextParentId: string | null }): void;
+    onReorder?(payload: { elementId: string; targetId: string; position: "before" | "after" }): void;
+    onDragStateChange?(elementId: string | null): void;
+}
+
+export interface StructureTreeState {
+    elements: LayoutElement[];
+    selectedId: string | null;
+    draggedElementId: string | null;
+}
+
+type DropIntent =
+    | { type: "reparent"; parentId: string | null }
+    | { type: "reorder"; targetId: string; position: "before" | "after" };
+
+export class StructureTreeComponent extends UIComponent<HTMLElement> {
+    private elements: LayoutElement[] = [];
+    private selectedId: string | null = null;
+    private draggedElementId: string | null = null;
+    private entryElements = new Map<string, HTMLElement>();
+    private rootDropZone: HTMLElement | null = null;
+    private transientCleanups: Array<() => void> = [];
+
+    constructor(private readonly options: StructureTreeComponentOptions) {
+        super();
+    }
+
+    protected onMount(host: HTMLElement): void {
+        this.renderTree(host);
+    }
+
+    protected onDestroy(): void {
+        this.entryElements.clear();
+        this.rootDropZone = null;
+        this.flushTransientCleanups();
+    }
+
+    setState(state: StructureTreeState) {
+        this.elements = state.elements;
+        this.selectedId = state.selectedId;
+        this.draggedElementId = state.draggedElementId;
+        this.renderTree();
+    }
+
+    private renderTree(hostArg?: HTMLElement) {
+        const host = hostArg ?? (() => {
+            try {
+                return this.requireHost();
+            } catch {
+                return null;
+            }
+        })();
+        if (!host) return;
+
+        this.flushTransientCleanups();
+        this.clearHost(host);
+        this.entryElements.clear();
+        this.rootDropZone = null;
+
+        if (!this.elements.length) {
+            host.createDiv({ cls: "sm-le-empty", text: "Noch keine Elemente." });
+            return;
+        }
+
+        const elementById = new Map(this.elements.map(element => [element.id, element]));
+        const childrenByParent = new Map<string | null, LayoutElement[]>();
+
+        for (const element of this.elements) {
+            const parentExists = element.parentId && elementById.has(element.parentId) ? element.parentId : null;
+            const key = parentExists ?? null;
+            const bucket = childrenByParent.get(key);
+            if (bucket) {
+                bucket.push(element);
+            } else {
+                childrenByParent.set(key, [element]);
+            }
+        }
+
+        for (const element of this.elements) {
+            if (!isContainerElement(element) || !element.children?.length) continue;
+            const list = childrenByParent.get(element.id);
+            if (!list) continue;
+            const lookup = new Map(list.map(child => [child.id, child]));
+            const ordered: LayoutElement[] = [];
+            for (const childId of element.children) {
+                const child = lookup.get(childId);
+                if (child) {
+                    ordered.push(child);
+                    lookup.delete(childId);
+                }
+            }
+            for (const child of list) {
+                if (lookup.has(child.id)) {
+                    ordered.push(child);
+                }
+            }
+            childrenByParent.set(element.id, ordered);
+        }
+
+        this.rootDropZone = host.createDiv({
+            cls: "sm-le-structure__root-drop",
+            text: "Ziehe ein Element hierher, um es aus seinem Container zu lösen.",
+        });
+
+        this.registerRootDropZone(elementById);
+
+        this.renderLevel(null, host, childrenByParent, elementById);
+    }
+
+    private renderLevel(
+        parentId: string | null,
+        container: HTMLElement,
+        childrenByParent: Map<string | null, LayoutElement[]>,
+        elementById: Map<string, LayoutElement>,
+    ) {
+        const children = childrenByParent.get(parentId);
+        if (!children || !children.length) return;
+        const listEl = container.createEl("ul", { cls: "sm-le-structure__list" });
+        for (const child of children) {
+            const itemEl = listEl.createEl("li", { cls: "sm-le-structure__item" });
+            const entry = itemEl.createEl("button", { cls: "sm-elements-button sm-le-structure__entry", text: "" });
+            entry.type = "button";
+            entry.dataset.id = child.id;
+            if (this.selectedId === child.id) {
+                entry.addClass("is-selected");
+            }
+            if (isContainerElement(child)) {
+                entry.addClass("sm-le-structure__entry--container");
+            }
+            entry.addClass("is-draggable");
+            entry.draggable = true;
+            this.entryElements.set(child.id, entry);
+
+            const name = child.label?.trim() || getElementTypeLabel(child.type);
+            entry.createSpan({ cls: "sm-le-structure__title", text: name });
+            const parentElement = child.parentId ? elementById.get(child.parentId) ?? null : null;
+            const metaParts: string[] = [getElementTypeLabel(child.type)];
+            if (parentElement) {
+                const parentName = parentElement.label?.trim() || getElementTypeLabel(parentElement.type);
+                metaParts.push(`Übergeordnet: ${parentName}`);
+            }
+            if (isContainerElement(child)) {
+                const count = child.children?.length ?? 0;
+                const label = count === 1 ? "1 Kind" : `${count} Kinder`;
+                metaParts.push(label);
+            }
+            entry.createSpan({ cls: "sm-le-structure__meta", text: metaParts.join(" • ") });
+
+            this.trackCleanup(
+                this.listen(entry, "click", event => {
+                    event.preventDefault();
+                    this.options.onSelect?.(child.id);
+                }),
+            );
+
+            this.trackCleanup(
+                this.listen(entry, "dragstart", dragEvent => {
+                    this.updateDragState(child.id, true);
+                    dragEvent.dataTransfer?.setData("text/plain", child.id);
+                    if (dragEvent.dataTransfer) {
+                        dragEvent.dataTransfer.effectAllowed = "move";
+                    }
+                }),
+            );
+
+            this.trackCleanup(
+                this.listen(entry, "dragend", () => {
+                    this.updateDragState(null, true);
+                    this.clearDropHighlights();
+                }),
+            );
+
+            this.trackCleanup(
+                this.listen(entry, "dragenter", dragEvent => {
+                    const intent = this.resolveDropIntent(entry, child, dragEvent as DragEvent);
+                    if (!intent) return;
+                    dragEvent.preventDefault();
+                    this.applyDropIndicator(entry, intent);
+                }),
+            );
+
+            this.trackCleanup(
+                this.listen(entry, "dragover", dragEvent => {
+                    const intent = this.resolveDropIntent(entry, child, dragEvent as DragEvent);
+                    if (!intent) {
+                        return;
+                    }
+                    dragEvent.preventDefault();
+                    if (dragEvent.dataTransfer) {
+                        dragEvent.dataTransfer.dropEffect = "move";
+                    }
+                    this.applyDropIndicator(entry, intent);
+                }),
+            );
+
+            this.trackCleanup(
+                this.listen(entry, "dragleave", dragEvent => {
+                    const related = dragEvent.relatedTarget as HTMLElement | null;
+                    if (!related || !entry.contains(related)) {
+                        this.clearEntryHighlight(entry);
+                    }
+                }),
+            );
+
+            this.trackCleanup(
+                this.listen(entry, "drop", dropEvent => {
+                    const intent = this.resolveDropIntent(entry, child, dropEvent as DragEvent);
+                    if (!intent) return;
+                    dropEvent.preventDefault();
+                    dropEvent.stopPropagation();
+                    const draggedId = this.draggedElementId;
+                    if (!draggedId) return;
+                    if (intent.type === "reparent") {
+                        this.options.onReparent?.({ elementId: draggedId, nextParentId: intent.parentId });
+                    } else {
+                        this.options.onReorder?.({
+                            elementId: draggedId,
+                            targetId: intent.targetId,
+                            position: intent.position,
+                        });
+                    }
+                    this.updateDragState(null, true);
+                    this.clearDropHighlights();
+                }),
+            );
+
+            this.renderLevel(child.id, itemEl, childrenByParent, elementById);
+        }
+    }
+
+    private registerRootDropZone(elementById: Map<string, LayoutElement>) {
+        if (!this.rootDropZone) return;
+        const canDropToRoot = () => {
+            if (!this.draggedElementId) return false;
+            const dragged = elementById.get(this.draggedElementId);
+            if (!dragged) return false;
+            return Boolean(dragged.parentId);
+        };
+
+        this.trackCleanup(
+            this.listen(this.rootDropZone, "dragenter", event => {
+                if (!canDropToRoot()) return;
+                event.preventDefault();
+                this.rootDropZone?.addClass("is-active");
+            }),
+        );
+
+        this.trackCleanup(
+            this.listen(this.rootDropZone, "dragover", event => {
+                if (!canDropToRoot()) return;
+                event.preventDefault();
+                if (event.dataTransfer) {
+                    event.dataTransfer.dropEffect = "move";
+                }
+                this.rootDropZone?.addClass("is-active");
+            }),
+        );
+
+        this.trackCleanup(
+            this.listen(this.rootDropZone, "dragleave", event => {
+                const related = event.relatedTarget as HTMLElement | null;
+                if (!related || !this.rootDropZone?.contains(related)) {
+                    this.rootDropZone?.removeClass("is-active");
+                }
+            }),
+        );
+
+        this.trackCleanup(
+            this.listen(this.rootDropZone, "drop", event => {
+                if (!canDropToRoot()) return;
+                event.preventDefault();
+                event.stopPropagation();
+                const draggedId = this.draggedElementId;
+                if (draggedId) {
+                    this.options.onReparent?.({ elementId: draggedId, nextParentId: null });
+                }
+                this.updateDragState(null, true);
+                this.clearDropHighlights();
+            }),
+        );
+    }
+
+    private updateDragState(id: string | null, notify: boolean) {
+        if (this.draggedElementId === id) return;
+        this.draggedElementId = id;
+        if (notify) {
+            this.options.onDragStateChange?.(id);
+        }
+    }
+
+    private resolveDropIntent(entry: HTMLElement, target: LayoutElement, event: DragEvent): DropIntent | null {
+        const draggedId = this.draggedElementId;
+        if (!draggedId || draggedId === target.id) return null;
+        const dragged = this.elements.find(el => el.id === draggedId);
+        if (!dragged) return null;
+        const rect = entry.getBoundingClientRect();
+        if (!rect.height) return null;
+        const offset = event.clientY - rect.top;
+        const ratio = offset / rect.height;
+        const canDropInto = isContainerElement(target) && this.canDropOnContainer(target, dragged);
+        if (canDropInto && ratio > 0.3 && ratio < 0.7) {
+            return { type: "reparent", parentId: target.id };
+        }
+        if (dragged.parentId && dragged.parentId === target.parentId) {
+            return { type: "reorder", targetId: target.id, position: ratio < 0.5 ? "before" : "after" };
+        }
+        if (canDropInto) {
+            return { type: "reparent", parentId: target.id };
+        }
+        return null;
+    }
+
+    private canDropOnContainer(container: LayoutElement, dragged: LayoutElement) {
+        if (!isContainerElement(container)) return false;
+        if (dragged.id === container.id) return false;
+        if (dragged.parentId === container.id) return false;
+        if (isContainerElement(dragged)) {
+            const descendants = collectDescendantIds(dragged, this.elements);
+            if (descendants.has(container.id)) return false;
+        }
+        let cursor = container.parentId ? this.elements.find(el => el.id === container.parentId) : null;
+        while (cursor) {
+            if (cursor.id === dragged.id) return false;
+            cursor = cursor.parentId ? this.elements.find(el => el.id === cursor.parentId) : null;
+        }
+        return true;
+    }
+
+    private applyDropIndicator(entry: HTMLElement, intent: DropIntent) {
+        this.clearDropHighlights();
+        entry.addClass("is-drop-target");
+        if (intent.type === "reorder") {
+            entry.setAttr("data-drop-position", intent.position);
+        } else {
+            entry.setAttr("data-drop-position", "inside");
+        }
+    }
+
+    private clearEntryHighlight(entry: HTMLElement) {
+        entry.removeClass("is-drop-target");
+        entry.removeAttr("data-drop-position");
+    }
+
+    private clearDropHighlights() {
+        for (const entry of this.entryElements.values()) {
+            this.clearEntryHighlight(entry);
+        }
+        this.rootDropZone?.removeClass("is-active");
+    }
+
+    private trackCleanup(cleanup: () => void) {
+        this.transientCleanups.push(cleanup);
+    }
+
+    private flushTransientCleanups() {
+        for (const cleanup of this.transientCleanups.splice(0)) {
+            cleanup();
+        }
+    }
+}

--- a/layout-editor/tests/run-tests.mjs
+++ b/layout-editor/tests/run-tests.mjs
@@ -2,27 +2,33 @@ import { build } from "esbuild";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { spawnSync } from "node:child_process";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, readdirSync } from "node:fs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const entry = join(__dirname, "layout-editor-store.test.ts");
 const outDir = join(__dirname, "dist");
-const outFile = join(outDir, "layout-editor-store.test.mjs");
 
 mkdirSync(outDir, { recursive: true });
 
-await build({
-    entryPoints: [entry],
-    bundle: true,
-    platform: "node",
-    format: "esm",
-    sourcemap: false,
-    outfile: outFile,
-    logLevel: "error",
-});
+const testEntries = readdirSync(__dirname)
+    .filter(file => file.endsWith(".test.ts"))
+    .sort();
 
-const result = spawnSync(process.execPath, [outFile], { stdio: "inherit" });
-if (result.status !== 0) {
-    process.exit(result.status ?? 1);
+for (const entryName of testEntries) {
+    const entry = join(__dirname, entryName);
+    const outFile = join(outDir, entryName.replace(/\.ts$/, ".mjs"));
+    await build({
+        entryPoints: [entry],
+        bundle: true,
+        platform: "node",
+        format: "esm",
+        sourcemap: false,
+        outfile: outFile,
+        logLevel: "error",
+    });
+
+    const result = spawnSync(process.execPath, [outFile], { stdio: "inherit" });
+    if (result.status !== 0) {
+        process.exit(result.status ?? 1);
+    }
 }

--- a/layout-editor/tests/ui-component.test.ts
+++ b/layout-editor/tests/ui-component.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { UIComponent, renderComponent } from "../src/ui/components/component";
+
+class FakeElement extends EventTarget {
+    private listenerCounts = new Map<string, number>();
+
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) {
+        super.addEventListener(type, listener as EventListener, options);
+        this.listenerCounts.set(type, (this.listenerCounts.get(type) ?? 0) + 1);
+    }
+
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions) {
+        super.removeEventListener(type, listener as EventListener, options);
+        const next = (this.listenerCounts.get(type) ?? 1) - 1;
+        this.listenerCounts.set(type, Math.max(0, next));
+    }
+
+    listenerCount(type: string): number {
+        return this.listenerCounts.get(type) ?? 0;
+    }
+}
+
+class ClickCounterComponent extends UIComponent<HTMLElement> {
+    count = 0;
+
+    protected onMount(host: HTMLElement): void {
+        this.listen(host, "ping", () => {
+            this.count += 1;
+        });
+    }
+}
+
+class TrackingComponent extends UIComponent<HTMLElement> {
+    destroyCount = 0;
+
+    protected onMount(): void {}
+
+    protected onDestroy(): void {
+        this.destroyCount += 1;
+    }
+}
+
+async function run() {
+    const host = new FakeElement() as unknown as HTMLElement;
+    const component = new ClickCounterComponent();
+    component.mount(host);
+    assert.equal(host.listenerCount("ping"), 1, "listener should be registered on mount");
+    host.dispatchEvent(new Event("ping"));
+    assert.equal(component.count, 1, "listener should increment count");
+    component.destroy();
+    assert.equal(host.listenerCount("ping"), 0, "listener should be removed after destroy");
+    host.dispatchEvent(new Event("ping"));
+    assert.equal(component.count, 1, "destroyed component should ignore events");
+
+    const secondHost = new FakeElement() as unknown as HTMLElement;
+    const first = new TrackingComponent();
+    const second = new TrackingComponent();
+    renderComponent(secondHost, first);
+    renderComponent(secondHost, second);
+    assert.equal(first.destroyCount, 1, "renderComponent should destroy previous component on host");
+    assert.equal(second.destroyCount, 0, "new component should not be destroyed immediately");
+
+    console.log("ui-component tests passed");
+}
+
+run().catch(error => {
+    console.error(error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a reusable UIComponent base class with primitive wrappers to standardize lifecycle cleanup
- extract editor shell, stage, and structure tree components and wire them through the view and presenters
- refresh documentation and tests to cover the new component architecture

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d63ce05f3c832596d8959b825df6f6