### PR TITLE
Add linting, formatting scripts and modernize test runner

### DIFF
--- a/layout-editor/.eslintrc.cjs
+++ b/layout-editor/.eslintrc.cjs
@@ -1,0 +1,47 @@
+module.exports = {
+  root: true,
+  env: {
+    es2022: true,
+    node: true,
+  },
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    project: false,
+  },
+  plugins: ["@typescript-eslint", "prettier"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended",
+  ],
+  ignorePatterns: ["dist/", "node_modules/"],
+  overrides: [
+    {
+      files: ["**/*.ts"],
+      parserOptions: {
+        project: undefined,
+      },
+      rules: {
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+      },
+    },
+    {
+      files: ["**/*.mjs"],
+      parser: null,
+      plugins: ["prettier"],
+      extends: ["eslint:recommended", "plugin:prettier/recommended"],
+      rules: {},
+    },
+    {
+      files: ["tests/**/*.ts"],
+      env: {
+        node: true,
+      },
+      rules: {
+        "@typescript-eslint/no-floating-promises": "off",
+      },
+    },
+  ],
+};

--- a/layout-editor/docs/tooling.md
+++ b/layout-editor/docs/tooling.md
@@ -1,0 +1,19 @@
+# Tooling
+
+This project relies on shared linting, formatting, and test tooling to keep contributions consistent and verifiable. The commands below run locally and in CI.
+
+## Linting
+
+- `npm run lint` – Runs ESLint with the TypeScript ruleset against the source, scripts, and test directories. The command fails on any lint error or warning.
+- `npm run lint -- --fix` or `npm run lint:fix` – Applies automatic fixes for supported rules.
+
+## Formatting
+
+- `npm run format` – Checks that files adhere to the configured Prettier formatting rules.
+- `npm run format:fix` – Rewrites the same set of files using Prettier defaults.
+
+## Tests
+
+- `npm test` – Builds each `*.test.ts` file under `tests/` with esbuild and executes them with Node.js. The runner fails fast on the first error and reports overall progress.
+
+Add new test files under `tests/` using the `*.test.ts` naming convention to have them discovered automatically.

--- a/layout-editor/package-lock.json
+++ b/layout-editor/package-lock.json
@@ -9,8 +9,14 @@
       "version": "0.1.0",
       "devDependencies": {
         "@types/node": "^20.12.12",
+        "@typescript-eslint/eslint-plugin": "^7.16.1",
+        "@typescript-eslint/parser": "^7.16.1",
         "esbuild": "^0.21.5",
+        "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-prettier": "^5.1.3",
         "obsidian": "^1.6.0",
+        "prettier": "^3.3.3",
         "typescript": "^5.5.4"
       }
     },

--- a/layout-editor/package.json
+++ b/layout-editor/package.json
@@ -6,12 +6,22 @@
   "main": "main.js",
   "scripts": {
     "build": "node scripts/generate-component-manifest.mjs && node esbuild.config.mjs",
-    "test": "node tests/run-tests.mjs"
+    "format": "prettier --check \"src/**/*.{ts,tsx}\" \"scripts/**/*.mjs\" \"tests/**/*.ts\" \"docs/**/*.md\"",
+    "format:fix": "prettier --write \"src/**/*.{ts,tsx}\" \"scripts/**/*.mjs\" \"tests/**/*.ts\" \"docs/**/*.md\"",
+    "lint": "eslint --max-warnings=0 \"src/**/*.{ts,tsx}\" \"scripts/**/*.mjs\" \"tests/**/*.ts\"",
+    "lint:fix": "npm run lint -- --fix",
+    "test": "node scripts/run-tests.mjs"
   },
   "devDependencies": {
-    "esbuild": "^0.21.5",
-    "typescript": "^5.5.4",
     "@types/node": "^20.12.12",
-    "obsidian": "^1.6.0"
+    "@typescript-eslint/eslint-plugin": "^7.16.1",
+    "@typescript-eslint/parser": "^7.16.1",
+    "esbuild": "^0.21.5",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "obsidian": "^1.6.0",
+    "prettier": "^3.3.3",
+    "typescript": "^5.5.4"
   }
 }

--- a/layout-editor/scripts/run-tests.mjs
+++ b/layout-editor/scripts/run-tests.mjs
@@ -1,0 +1,89 @@
+import { build } from "esbuild";
+import { spawn } from "node:child_process";
+import { mkdir, readdir } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, extname, join, relative, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = resolve(__dirname, "..");
+const testsRoot = join(projectRoot, "tests");
+const cacheDir = join(projectRoot, "node_modules", ".cache", "layout-editor-tests");
+
+async function collectTests(dir) {
+    const entries = await readdir(dir, { withFileTypes: true });
+    const files = [];
+    for (const entry of entries) {
+        if (entry.name.startsWith(".")) {
+            continue;
+        }
+        const absolutePath = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            const nested = await collectTests(absolutePath);
+            files.push(...nested);
+            continue;
+        }
+        if (entry.isFile() && entry.name.endsWith(".test.ts")) {
+            files.push(absolutePath);
+        }
+    }
+    files.sort((a, b) => a.localeCompare(b));
+    return files;
+}
+
+async function ensureDir(path) {
+    await mkdir(path, { recursive: true });
+}
+
+async function runTestFile(testFile, index, total) {
+    const relativePath = relative(projectRoot, testFile);
+    const outFile = join(cacheDir, relativePath).replace(extname(testFile), ".mjs");
+    await ensureDir(dirname(outFile));
+
+    console.log(`\n[${index}/${total}] Building ${relativePath}`);
+    await build({
+        entryPoints: [testFile],
+        bundle: true,
+        platform: "node",
+        format: "esm",
+        target: "node18",
+        sourcemap: "inline",
+        outfile: outFile,
+        logLevel: "silent",
+    });
+
+    console.log(`[${index}/${total}] Running ${relativePath}`);
+    await new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [outFile], { stdio: "inherit" });
+        child.on("error", reject);
+        child.on("exit", code => {
+            if (code === 0) {
+                resolve();
+                return;
+            }
+            reject(new Error(`${relativePath} exited with status ${code ?? "unknown"}`));
+        });
+    });
+}
+
+async function main() {
+    const testFiles = await collectTests(testsRoot);
+    if (testFiles.length === 0) {
+        console.log("No test files found. Add *.test.ts files under tests/ to enable coverage.");
+        return;
+    }
+
+    console.log(`Discovered ${testFiles.length} test file${testFiles.length === 1 ? "" : "s"}.`);
+
+    for (let index = 0; index < testFiles.length; index += 1) {
+        const ordinal = index + 1;
+        await runTestFile(testFiles[index], ordinal, testFiles.length);
+    }
+
+    console.log(`\nAll ${testFiles.length} test file${testFiles.length === 1 ? "" : "s"} passed.`);
+}
+
+main().catch(error => {
+    console.error("\nTest runner failed:\n", error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add eslint and prettier npm scripts alongside required configuration
- move the custom TypeScript test harness under scripts/ so npm test can call it directly
- document how to lint, format, and run tests in docs/tooling.md

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d68e66c0e88325b633f5f0ffb1461f