### PR TITLE
Introduce API and schema versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,56 @@
 # Layout-Editor
-An Obsidian Plugin developed to help you quickly and comfortably design complex layouts for other obsidian plugins.
 
-Geplante Features:
-  Eine Layout Editor Ansicht die:
-  - Über eine intuitive echtzeit Arbeitsfläche verfügt, in der man Layouts interaktiv designen kann
-  - Mit Godot-ähnlicher Node Übersicht zur Linken
-  - Mit godot-ähnlicher Element Bearbeiten funktionen zur rechten
-  - Erstellte Layouts werden in einen "LE-Layouts" Ordner im Obsidian Vault gespeichert, von wo aus sie erneut geöffnet werden können um weiter an ihnen zu arbeiten odre von anderen Plugis genutzt werden können.
-  - Ui Komponenten können über eine godot-ähnliche node-auswahl zur Arbeitsfläche hinzugefügt werden.
-  - UI Elemente werden aus einem LE-Elements Ordner im Vault gezogen, in welchem user ganz einfach eigene Elemente hinzufügen können. Alle Elemente sind deshalb komplett selfcontained, es sei denn sie inheriten Funktionen von anderen Elementen.
-    
-  UI Elemente enthalten:
-  - Textfelder zum anzeigen oder editieren von Text
-  - Buttons, checkboxen und andere Elemente, welche mit Funktionen anderer Plugins verbunden werden können, solange diese in einem LE-Functions Ordner im Vault gespeichert sind
-  - View-container, welche mit renderausgaben verbunden werden können, solange diese aus einem LE-Views ordner im Vault importiert werden können.
-  - Listen, Dropdown Menüs und andere Elemente, welche mit Daten aus anderen Plugins gefüttert werden können, solange diese aus einem LE-Data Ordner im Vault importiert weden können.
+Der Layout-Editor ist ein Obsidian-Plugin zum Entwerfen komplexer Formular- und Dashboard-Layouts, die von anderen Plugins wiederverwendet werden können. Der Editor stellt eine Canvas-Ansicht, Element-Bibliotheken sowie eine Persistenzschicht für Layout-Dateien bereit.
 
-  Eingebaute Layouts enthalten:
-  - Das Layout des Layout Editors selbst, damit User es selber nach ihrem Bedarf anpassen können.
+## Kernfunktionen
 
-  Eingebaute LE-Functions enthalten:
-  - ein Exporter, welcher Daten aus UI Elementen in einem importfreundlichen Format in LE-Data speichert
-  - Alle Funktionen des Editors, damit User den Editor selber nach eigeneme Bedarf anpassen können.
+- **Interaktive Editor-Ansicht** – Öffne den Layout-Editor als eigene Obsidian-View mit Canvas, Strukturbaum und Inspector, um Layouts visuell zu modellieren.
+- **Erweiterbare Elementbibliothek** – Registriere eigene UI-Komponenten und View-Bindings über die öffentliche Plugin-API.
+- **Layout-Bibliothek** – Speichere Layouts im Vault, lade sie erneut oder teile sie mit anderen Plugins.
+- **Versionierte Plugin-API** – `apiVersion` kennzeichnet das veröffentlichte API-Level, Helfer wie `isApiVersionAtLeast` und `withMinimumApiVersion` erlauben defensive Feature-Gates.
+- **Schema-Migrationen** – Gespeicherte Layouts enthalten ein `schemaVersion`-Feld. Die Bibliothek führt Migrationen zentral aus und warnt bei fehlenden Pfaden oder zukünftigen Versionen.
+
+## Nutzung & Workflows
+
+1. **Editor öffnen**: Über das Ribbon-Icon oder den Befehl „Layout Editor öffnen“ wird die dedizierte View aktiviert.
+2. **Layouts modellieren**: Elemente aus der Bibliothek auf die Arbeitsfläche ziehen, Eigenschaften im Inspector anpassen und optional View-Bindings zuweisen.
+3. **Layout speichern**: Über die Speicher-Controls wird ein Layout unter einer ID im Vault abgelegt. Bestehende Einträge werden migrationssicher überschrieben.
+4. **Layouts laden/teilen**: Plugins können via API Layouts laden und mit `schemaVersion`-Checks gegen das aktuelle Schema absichern.
+
+## Öffentliche API & Versionierung
+
+- Jede Instanz von `LayoutEditorPlugin.getApi()` liefert ein Objekt mit `apiVersion` sowie den Helfern `isApiVersionAtLeast`, `assertApiVersion` und `withMinimumApiVersion`.
+- Neue Features werden hinter Versionsprüfungen freigeschaltet. Konsumenten können so optional auf neue Funktionen reagieren, ohne ältere Plugin-Versionen zu brechen.
+- Die aktuell ausgelieferte API-Version lautet `1.0.0`.
+
+### Kompatibilitäts-Helfer
+
+```ts
+const api = plugin.getApi();
+api.assertApiVersion("1.0.0");
+const result = api.withMinimumApiVersion("1.1.0", () => useNewFeature());
+```
+
+Weitere Details zur API-Evolution und Migrationsregeln sind unter [`docs/api-migrations.md`](docs/api-migrations.md) beschrieben.
+
+## Layout-Schema-Migrationen
+
+Gespeicherte Layout-Dateien werden mit einem `schemaVersion` versehen. Beim Laden werden sie durch einen zentralen Runner (`runLayoutSchemaMigrations`) geführt. Dieser
+
+- aktualisiert Legacy-Dateien auf das aktuelle Schema,
+- gibt Warnungen aus, sobald Migrationen angewendet werden oder Pfade fehlen,
+- verweigert Layouts, deren Schema neuer ist als die implementierte Version.
+
+Durch Tests (`tests/api-versioning.test.ts`) wird sichergestellt, dass Legacy-Layouts weiterhin eingelesen werden können und zukünftige Schemen defensiv abgelehnt werden.
+
+## Entwicklung & Tests
+
+- Abhängigkeiten installieren: `npm install`
+- Tests ausführen: `npm test`
+
+Die Tests bundlen über esbuild und führen alle `*.test.ts`-Dateien in `layout-editor/tests` aus.
+
+## Weiterführende Dokumentation
+
+- [`docs/api-migrations.md`](docs/api-migrations.md) – Richtlinien für API-Änderungen und Layout-Migrationen.
+

--- a/docs/api-migrations.md
+++ b/docs/api-migrations.md
@@ -1,0 +1,69 @@
+# API- und Layout-Migrationen
+
+Dieses Dokument beschreibt die Versionierungsstrategie des Layout-Editor-Plugins sowie den Workflow zum Einführen neuer API- oder Schema-Änderungen.
+
+## Plugin-API-Versionierung
+
+- Die exportierte Konstante `LAYOUT_EDITOR_API_VERSION` gibt die aktuell ausgelieferte API-Version an (SemVer).
+- `LayoutEditorPlugin.getApi()` liefert ein Objekt mit:
+  - `apiVersion`
+  - `isApiVersionAtLeast(version: string)`
+  - `assertApiVersion(version: string, featureName?: string)`
+  - `withMinimumApiVersion(version: string, feature: () => T)`
+- Verwende `withMinimumApiVersion`, um neue Funktionen nur dann auszuführen, wenn Konsumenten das erforderliche API-Level unterstützen.
+- `assertApiVersion` ist für harte Anforderungen gedacht (z. B. wenn ein Feature ohne das neue API-Level nicht funktionieren kann).
+- Bei Breaking Changes muss mindestens die Minor-Version erhöht werden. Dokumentiere das Verhalten im Changelog und aktualisiere Beispiele in README & Tests.
+
+### Workflow für API-Änderungen
+
+1. **Planung** – Definiere, welche Methoden/Signaturen geändert werden und welches minimale API-Level benötigt wird.
+2. **Implementation** – Implementiere die Funktionalität hinter einem Versions-Gate mittels `withMinimumApiVersion` oder `assertApiVersion`.
+3. **Dokumentation** – Aktualisiere README und ggf. Inline-Kommentare.
+4. **Tests** – Erweitere `tests/api-versioning.test.ts`, um neue Versionen und Fehlerszenarien abzudecken.
+
+## Layout-Schema-Versionierung
+
+Jede gespeicherte Layout-Datei enthält das Feld `schemaVersion`. Die Bibliothek definiert:
+
+- `LAYOUT_SCHEMA_VERSION`: aktuell unterstützte Zielversion.
+- `MIN_SUPPORTED_LAYOUT_SCHEMA_VERSION`: ältestes unterstütztes Schema, das migriert werden kann.
+- `runLayoutSchemaMigrations(layout, warn?)`: zentraler Runner, der Legacy-Dateien iterativ anhebt.
+
+Beim Laden eines Layouts:
+
+1. Das JSON wird normalisiert (Pflichtfelder, Fallbacks).
+2. `schemaVersion` wird ermittelt, fehlende Werte werden als `0` interpretiert.
+3. `runLayoutSchemaMigrations` führt definierte Migrationen aus und gibt Warnungen aus:
+   - wenn Migrationen angewendet werden,
+   - wenn Pfade fehlen oder keine höhere Version erreicht wird,
+   - wenn das Layout ein zukünftiges Schema nutzt (Layout wird verworfen).
+
+### Migrationen hinzufügen
+
+1. **Neue Version wählen** – Erhöhe `LAYOUT_SCHEMA_VERSION` um mindestens `+1`.
+2. **Migration implementieren** – Ergänze `LAYOUT_SCHEMA_MIGRATIONS` um eine Funktion für den Übergang von `n` → `n+1`.
+3. **Daten anpassen** – Passe innerhalb der Migration alle Schemaänderungen an und setze `schemaVersion` auf die neue Zielversion.
+4. **Warnungen prüfen** – Stelle sicher, dass die Migration bei Erfolg den Hinweis „migriert“ ausgibt und im Fehlerfall eine aussagekräftige Warnung erzeugt.
+5. **Tests erweitern** – Ergänze `tests/api-versioning.test.ts` (oder eigene Tests), um Legacy-Layouts gegen die neue Migration zu prüfen.
+6. **Dokumentation aktualisieren** – Beschreibe das neue Schema sowie erforderliche Konsument:innen-Anpassungen im README oder ergänzenden Dokumenten.
+
+### Fehlende Migrationen
+
+Wenn ein Layout eine ältere Version besitzt, für die keine Migration definiert ist, verwirft `runLayoutSchemaMigrations` die Datei und erzeugt eine Warnung. Dies signalisiert, dass eine Migration nachgerüstet werden muss, bevor das Layout wieder geladen werden kann.
+
+### Zukünftige Schemen
+
+Layouts mit einer höheren `schemaVersion` als `LAYOUT_SCHEMA_VERSION` gelten als inkompatibel. Sie werden nicht geladen, damit keine fehlerhaften Daten verarbeitet werden. Ein entsprechender Warnhinweis wird ausgegeben.
+
+## Tests & Qualitätssicherung
+
+- `tests/api-versioning.test.ts` enthält Regressionstests für API-Helfer und Migrationen.
+- Ergänze neue Tests bei jeder Änderung an API oder Schema.
+
+## Best Practices
+
+- Vermeide breaking Changes ohne Versionssprung.
+- Halte Migrationen idempotent und funktional (keine Seiteneffekte außerhalb des Layout-Objekts).
+- Protokolliere Warnungen so, dass Vault-Pfad und Layout-ID nachvollziehbar bleiben.
+- Entferne alte Migrationen erst, wenn die entsprechenden Schemen offiziell nicht mehr unterstützt werden.
+

--- a/layout-editor/src/index.ts
+++ b/layout-editor/src/index.ts
@@ -1,5 +1,11 @@
 // plugins/layout-editor/src/index.ts
-export { default as LayoutEditorPlugin, type LayoutEditorPluginApi } from "./main";
+export {
+    default as LayoutEditorPlugin,
+    type LayoutEditorPluginApi,
+    LAYOUT_EDITOR_API_VERSION,
+    createLayoutEditorApiCompatibility,
+    type LayoutEditorApiCompatibility,
+} from "./main";
 export { LayoutEditorView, VIEW_LAYOUT_EDITOR } from "./view";
 export {
     DEFAULT_ELEMENT_DEFINITIONS,
@@ -9,7 +15,15 @@ export {
     resetLayoutElementDefinitions,
     unregisterLayoutElementDefinition,
 } from "./definitions";
-export { listSavedLayouts, loadSavedLayout, saveLayoutToLibrary } from "./layout-library";
+export {
+    listSavedLayouts,
+    loadSavedLayout,
+    saveLayoutToLibrary,
+    runLayoutSchemaMigrations,
+    LAYOUT_SCHEMA_VERSION,
+    MIN_SUPPORTED_LAYOUT_SCHEMA_VERSION,
+    type VersionedSavedLayout,
+} from "./layout-library";
 export {
     getViewBinding,
     getViewBindings,

--- a/layout-editor/tests/api-versioning.test.ts
+++ b/layout-editor/tests/api-versioning.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import {
+    runLayoutSchemaMigrations,
+    LAYOUT_SCHEMA_VERSION,
+    type VersionedSavedLayout,
+} from "../src/layout-library";
+
+async function runTests() {
+    const baseLayout: VersionedSavedLayout = {
+        id: "legacy",
+        name: "Legacy Layout",
+        canvasWidth: 800,
+        canvasHeight: 600,
+        elements: [
+            {
+                id: "el-1",
+                type: "label",
+                x: 0,
+                y: 0,
+                width: 120,
+                height: 32,
+                label: "Legacy",
+                attributes: [],
+            },
+        ],
+        createdAt: new Date("2020-01-01T00:00:00.000Z").toISOString(),
+        updatedAt: new Date("2020-01-02T00:00:00.000Z").toISOString(),
+        schemaVersion: 0,
+    };
+
+    const migrationWarnings: string[] = [];
+    const migrated = runLayoutSchemaMigrations({ ...baseLayout }, message => {
+        migrationWarnings.push(message);
+    });
+    assert.ok(migrated, "legacy layout should migrate successfully");
+    assert.equal(migrated?.schemaVersion, LAYOUT_SCHEMA_VERSION, "layout should match current schema version");
+    assert.ok(
+        migrationWarnings.some(message => message.includes("migriert")),
+        "migration should emit a warning about the schema update",
+    );
+
+    const futureWarnings: string[] = [];
+    const futureLayout: VersionedSavedLayout = {
+        ...baseLayout,
+        id: "future",
+        schemaVersion: LAYOUT_SCHEMA_VERSION + 5,
+    };
+    const futureResult = runLayoutSchemaMigrations(futureLayout, message => {
+        futureWarnings.push(message);
+    });
+    assert.equal(futureResult, null, "layouts from the future should be rejected");
+    assert.ok(
+        futureWarnings.length > 0 && futureWarnings[0].includes("verwendet Schema-Version"),
+        "future schema rejection should emit a warning",
+    );
+
+    const stalledWarnings: string[] = [];
+    const stalledResult = runLayoutSchemaMigrations(
+        {
+            ...baseLayout,
+            schemaVersion: 0,
+        },
+        message => stalledWarnings.push(message),
+    );
+    assert.ok(stalledResult, "re-running migration should still succeed");
+    assert.ok(
+        stalledWarnings.filter(message => message.includes("migriert")).length >= 1,
+        "repeated migrations should emit consistent warnings",
+    );
+
+    console.log("api-versioning schema tests passed");
+}
+
+runTests().catch(error => {
+    console.error(error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add explicit API version metadata and compatibility helpers to the public plugin API
- version persisted layouts via a migration runner that upgrades legacy schemas and warns on incompatibilities
- document the versioning workflow and add regression coverage for loading legacy layouts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d68e6348f483259b35411903e3f935