### PR TITLE
Add settings tab for domain configuration toggle

### DIFF
--- a/layout-editor/docs/domain-configuration.md
+++ b/layout-editor/docs/domain-configuration.md
@@ -6,18 +6,23 @@ Validierungsregeln der Konfiguration sowie die notwendigen Schritte zur Aktivier
 
 ## Quellen auswählen
 
-1. Öffne die Plugin-Einstellungen des Layout Editors.
-2. Aktiviere unter **Domänenquelle** den Toggle, um vom Modus „Builtin“ auf „Vault“ zu
-   wechseln. Ohne Aktivierung bleiben die ursprünglichen Daten erhalten.
-3. Beim Umschalten wird die Domänenkonfiguration automatisch neu geladen und sowohl die
-   Element-Definitionen als auch die Seed-Layouts aktualisiert.
+1. Öffne die **Einstellungen** von Obsidian und navigiere zu **Community Plugins → Layout Editor**.
+2. Wähle den Reiter **Layout Editor**. Dort findest du den Toggle **Domänenquelle**.
+3. Schalte den Toggle auf den gewünschten Modus:
+   - **Builtin** lädt die mit dem Plugin ausgelieferten Attributgruppen, Element-Definitionen und Seed-Layouts.
+   - **Vault** lädt alle Bereiche aus deiner Vault-Datei `Layout Editor/domain-config.json` (siehe unten).
+4. Beim Umschalten wird die Domänenkonfiguration automatisch neu geladen und sowohl die Element-Definitionen
+   als auch die Seed-Layouts aktualisiert.
 
-Die Auswahl wird in `localStorage` des Clients gesichert, sodass der zuletzt verwendete Modus
-beim nächsten Start wiederhergestellt wird.
+Die Auswahl wird über `localStorage` pro Client gesichert, sodass der zuletzt verwendete Modus beim nächsten Start wiederhergestellt wird.
 
 ## Ablageort und Struktur der JSON-Datei
 
 * Dateipfad: `Layout Editor/domain-config.json` (relativ zum Vault-Stamm).
+* Voraussetzungen für den Vault-Modus:
+  - Die Datei muss existieren und valides JSON enthalten.
+  - Der Vault benötigt Schreib-/Leserechte für den Ordner `Layout Editor`.
+  - Änderungen an der Datei erfordern ein erneutes Laden des Toggles oder einen Neustart des Plugins, damit sie übernommen werden.
 * Erwartete Wurzelstruktur:
 
 ```json

--- a/layout-editor/src/main.ts
+++ b/layout-editor/src/main.ts
@@ -21,6 +21,7 @@ import {
 import type { LayoutBlueprint, LayoutElementDefinition, LayoutElementType } from "./types";
 import { LAYOUT_EDITOR_CSS } from "./css";
 import { ensureSeedLayouts } from "./seed-layouts";
+import { registerLayoutEditorSettingsTab } from "./settings/settings-tab";
 
 export const LAYOUT_EDITOR_API_VERSION = "1.0.0";
 
@@ -128,6 +129,8 @@ export default class LayoutEditorPlugin extends Plugin {
             name: "Layout Editor öffnen",
             callback: () => this.openView(),
         });
+
+        registerLayoutEditorSettingsTab(this);
 
         this.injectCss();
 

--- a/layout-editor/src/settings/settings-tab.ts
+++ b/layout-editor/src/settings/settings-tab.ts
@@ -1,0 +1,54 @@
+import type { App } from "obsidian";
+import { PluginSettingTab, Setting } from "obsidian";
+import type LayoutEditorPlugin from "../main";
+import { renderDomainConfigurationSetting } from "./domain-settings";
+
+class LayoutEditorSettingsTab extends PluginSettingTab {
+    private disposers: Array<() => void> = [];
+
+    constructor(app: App, plugin: LayoutEditorPlugin) {
+        super(app, plugin);
+    }
+
+    display(): void {
+        this.disposeAll();
+        const { containerEl } = this;
+        containerEl.empty();
+
+        containerEl.createEl("h2", { text: "Layout Editor" });
+
+        const domainSection = containerEl.createDiv({ cls: "layout-editor-settings" });
+        const domainSetting = new Setting(domainSection);
+        this.disposers.push(renderDomainConfigurationSetting(domainSetting));
+    }
+
+    hide(): void {
+        this.disposeAll();
+        super.hide();
+    }
+
+    private disposeAll(): void {
+        while (this.disposers.length > 0) {
+            const dispose = this.disposers.pop();
+            try {
+                dispose?.();
+            } catch (error) {
+                console.error("Layout Editor: Fehler beim Aufräumen der Settings", error);
+            }
+        }
+    }
+}
+
+export function registerLayoutEditorSettingsTab(plugin: LayoutEditorPlugin): void {
+    const tab = new LayoutEditorSettingsTab(plugin.app, plugin);
+    plugin.addSettingTab(tab);
+
+    plugin.register(() => {
+        const settingManager = (plugin.app as App & {
+            setting?: {
+                removeSettingTab?: (tab: PluginSettingTab) => void;
+            };
+        }).setting;
+        settingManager?.removeSettingTab?.(tab);
+    });
+}


### PR DESCRIPTION
## Summary
- register a Layout Editor settings tab that exposes the domain source toggle via Obsidian settings
- update the domain configuration setting renderer to manage lifecycle cleanup and reflect external changes
- document how to reach the toggle and the requirements for using vault-based domain data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6a02e4f188325a6890a201b019264