### PR TITLE
Batch export payload updates during drags

### DIFF
--- a/layout-editor/src/ui/components/stage.ts
+++ b/layout-editor/src/ui/components/stage.ts
@@ -257,6 +257,7 @@ export class StageComponent extends UIComponent<HTMLElement> {
                 this.options.store.applyContainerLayout(parent.id);
             }
             this.options.store.pushHistorySnapshot();
+            this.options.store.flushExport();
             onComplete();
         });
     }
@@ -328,6 +329,7 @@ export class StageComponent extends UIComponent<HTMLElement> {
                 this.options.store.applyContainerLayout(parent.id);
             }
             this.options.store.pushHistorySnapshot();
+            this.options.store.flushExport();
             onComplete();
         });
     }


### PR DESCRIPTION
## Summary
- memoize export payloads in the layout editor store and add a flush hook to prevent per-frame JSON serialization during drags
- trigger the new flush export hook from the stage component once move/resize interactions settle
- extend the store test suite and UI performance documentation to cover the batched export behaviour

## Testing
- npm --prefix layout-editor test -- layout-editor-store.test.ts *(fails later when unrelated suites try to resolve the Obsidian dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a02db69c8325931677392140bfe2