### PR TITLE
Add user documentation index and navigation cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,5 +67,5 @@ Die Tests bundlen über esbuild und führen alle `*.test.ts`-Dateien in `layout-
 - [`layout-editor/docs/i18n.md`](layout-editor/docs/i18n.md) – Leitfaden für Übersetzungen, Fallback-Strategien und Pluralisierung.
 - [`layout-editor/docs/tooling.md`](layout-editor/docs/tooling.md) – Übersicht über CLI-Helfer, Tests und Automatisierungen.
 
-Fortgeschrittene Leser finden künftig im zentralen Wiki-Index eine kuratierte Sammlung sämtlicher Deep-Dives, sobald dieser veröffentlicht ist.
+Eine kuratierte Übersicht aller nutzerorientierten Artikel findest du im [Docs-Index](docs/README.md). Dieses Wurzelverzeichnis konzentriert sich auf Workflows und How-Tos, während das technische Wiki in [`layout-editor/docs/`](layout-editor/docs/) tiefgehende Architektur- und API-Details bereitstellt.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# Benutzer-Dokumentation – Index
+
+Dieses Verzeichnis bündelt die nutzerorientierten Ergänzungen zum technischen Wiki im Ordner [`layout-editor/docs/`](../layout-editor/docs/). Hier findest du Schritt-für-Schritt-Anleitungen, Migrationshinweise und Querverweise, damit du den Layout-Editor sicher einsetzen kannst.
+
+## Dateien in `docs/`
+
+- [`api-migrations.md`](api-migrations.md) – Leitfaden für API-Änderungen, Layout-Schema-Migrationen sowie Qualitätschecks rund um Versionssprünge.
+
+## Verwandte Deep-Dives in `layout-editor/docs/`
+
+- [`plugin-api.md`](../layout-editor/docs/plugin-api.md) – Vollständige Referenz der öffentlichen Plugin-API inklusive Fehlerszenarien.
+- [`layout-library.md`](../layout-editor/docs/layout-library.md) – Nutzung der Layout-Bibliothek, Persistenzregeln und Wiederherstellungsabläufe.
+- [`data-model-overview.md`](../layout-editor/docs/data-model-overview.md) – Überblick über Layout-Entities, Beziehungen und Schemafelder.
+- [`persistence-errors.md`](../layout-editor/docs/persistence-errors.md) – Fehlermeldungen und Troubleshooting bei Speichern & Laden.
+- [`ui-performance.md`](../layout-editor/docs/ui-performance.md) – Optimierung von Rendering, Diffs und Interaktionen für große Layouts.
+- [`i18n.md`](../layout-editor/docs/i18n.md) – Lokalisierung und Übersetzungs-Workflow im Layout-Editor.
+- [`view-registry.md`](../layout-editor/docs/view-registry.md) – Lebenszyklus und Schutzmechanismen der View-Registry.
+- [`domain-configuration.md`](../layout-editor/docs/domain-configuration.md) – Konfiguration von Datenquellen und Sicherheitsmechanismen.
+- [`tooling.md`](../layout-editor/docs/tooling.md) – CLI-Helfer, Tests und Automatisierungen für Entwickler:innen.
+
+## Weiterführende Hinweise
+
+- Technische Detailentscheidungen findest du weiterhin direkt in den Deep-Dive-Dateien unter `layout-editor/docs/`.
+- Ergänzungen oder neue Artikel sollten hier verlinkt werden, damit Anwender:innen einen konsistenten Einstiegspunkt besitzen.

--- a/docs/api-migrations.md
+++ b/docs/api-migrations.md
@@ -67,3 +67,11 @@ Layouts mit einer höheren `schemaVersion` als `LAYOUT_SCHEMA_VERSION` gelten al
 - Protokolliere Warnungen so, dass Vault-Pfad und Layout-ID nachvollziehbar bleiben.
 - Entferne alte Migrationen erst, wenn die entsprechenden Schemen offiziell nicht mehr unterstützt werden.
 
+## Navigation
+
+- [Zurück zum Docs-Index](README.md)
+- Deep-Dive-Referenzen:
+  - [Plugin-API-Referenz](../layout-editor/docs/plugin-api.md)
+  - [Layout-Bibliothek & Persistenz](../layout-editor/docs/layout-library.md)
+  - [Datenmodell-Überblick](../layout-editor/docs/data-model-overview.md)
+


### PR DESCRIPTION
## Summary
- add a user-facing index for the docs folder with links into the technical wiki
- update the root README to explain how the user docs complement the layout-editor wiki
- add navigation links from the API migration guide back to the index and related deep dives

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d6adc42b688325891aea8f157e82bf