### PR TITLE
Add directory-level documentation for UI, tests, and scripts

### DIFF
--- a/layout-editor/scripts/README.md
+++ b/layout-editor/scripts/README.md
@@ -1,0 +1,18 @@
+# Skripte
+
+Die Skripte automatisieren Build-, Test- und Generierungsaufgaben für den Layout-Editor. Sie laufen als Node-ESM-Module und können direkt über `node` oder npm-Skripte gestartet werden.
+
+## Inhalte
+- [`generate-component-manifest.mjs`](generate-component-manifest.mjs) – Erstellt `src/elements/component-manifest.ts` aus allen registrierten Komponenten.
+- [`run-tests.mjs`](run-tests.mjs) – Bündelt sämtliche `tests/**/*.test.ts`-Dateien mit esbuild und führt sie sequenziell aus. Verwendet dieselbe Pipeline wie `npm test`.
+
+## Konventionen
+- **ESM-Only**: Skripte sind reine ES-Module. Verwende `import`/`export` und `fileURLToPath` für Pfadauflösungen.
+- **Nebenwirkungsfrei**: Skripte sollen keine Layout-Dateien mutieren. Outputs gehören in `src/elements/component-manifest.ts` oder `node_modules/.cache/layout-editor-tests`.
+- **CLI-Usage**: Parameter werden über Umgebungsvariablen oder Commander-Wrapper in nachgelagerten Aufgaben ergänzt. Beim Erweitern zuerst prüfen, ob [`../docs/tooling.md`](../docs/tooling.md) bestehende Flags beschreibt.
+- **Pfad-Konventionen**: Root über `resolve(__dirname, "..")` ermitteln; neue Skripte folgen diesem Muster, damit sie unabhängig vom Aufrufort funktionieren.
+
+## Weiterführende Dokumentation
+- Tooling-Überblick & Befehle: [`../docs/tooling.md`](../docs/tooling.md)
+- Modul-Architektur und Ownership: [`../src/LayoutEditorOverview.txt`](../src/LayoutEditorOverview.txt)
+- Projektweite Nutzung & Workflows: [`../../README.md`](../../README.md)

--- a/layout-editor/src/ui/README.md
+++ b/layout-editor/src/ui/README.md
@@ -1,0 +1,24 @@
+# UI Layer
+
+Dieser Ordner enthält die UI-Hilfsfunktionen des Layout-Editors – insbesondere Menü- und Baumrendering – und stellt die Verbindung zwischen dem Store (`src/state`) und den wiederverwendbaren UI-Komponenten her.
+
+## Inhalte
+- [`components/`](components/README.md) – Sammlung der komplexen UI-Komponenten (Stage, DiffRenderer, Shell usw.).
+- [`editor-menu.ts`](editor-menu.ts) – Erzeugt kontextuelle Aktionsmenüs für Canvas- und Bauminteraktionen.
+- [`element-tree.ts`](element-tree.ts) – Rendert die Element-Bibliothek als gruppierten Baum und meldet Selektionen.
+
+## Aufgaben & Verantwortlichkeiten
+- Kapselt DOM-Manipulationen, damit Presenter und Store ausschließlich Daten liefern.
+- Nutzt die Basisklasse `UIComponent` aus `components/component.ts`, um Listener/Cleanups sicher zu verwalten.
+- Bindet CSS-Klassen mit dem Präfix `sm-le-` und `sm-elements-` ein; neue Klassen folgen diesem Namensschema für konsistentes Styling.
+
+## Arbeitskonventionen
+- **Lebenszyklus**: UI-Komponenten müssen `mount()`/`destroy()` aus `UIComponent` nutzen. Direkte DOM-Eingriffe erfolgen nur innerhalb von `onMount`/`onDestroy` oder über `UIComponentScope`-Scopes.
+- **Event-Handling**: Ereignisse immer über `scope.listen` bzw. `this.listen` registrieren, damit Cleanups automatisch laufen.
+- **Element-Baum**: `ElementTreeNode.id` muss eindeutig sein; Gruppen ohne `definition` werden als reine Abschnittsüberschriften behandelt.
+- **Tests**: Änderungen an UI-Hilfen erfordern Aktualisierungen in `../../tests/ui-component.test.ts` bzw. `../../tests/ui-diff-renderer.test.ts`.
+
+## Weiterführende Dokumentation
+- Architektur-Überblick: [`../LayoutEditorOverview.txt`](../LayoutEditorOverview.txt)
+- Performance-Guidelines für UI-Widgets: [`../../docs/ui-performance.md`](../../docs/ui-performance.md)
+- Projektweite Einordnung & Workflows: [`../../../README.md`](../../../README.md)

--- a/layout-editor/src/ui/components/README.md
+++ b/layout-editor/src/ui/components/README.md
@@ -1,0 +1,24 @@
+# UI-Komponenten
+
+Die Komponenten in diesem Ordner implementieren die interaktiven Widgets der Canvas-Ansicht. Sie folgen dem `UIComponent`-Pattern, um DOM-Lebenszyklen und Eventlistener deterministisch zu verwalten.
+
+## Inhalte
+- [`component.ts`](component.ts) – Basisklasse `UIComponent` inkl. `UIComponentScope`, Listener-Verwaltung und `renderComponent`-Helper.
+- [`diff-renderer.ts`](diff-renderer.ts) – Leichtgewichtiger Renderer, der auf Key-basierten Diffs DOM-Bäume patcht.
+- [`editor-shell.ts`](editor-shell.ts) – Umschließender Rahmen für Toolbar, Stage und Inspector.
+- [`primitives.ts`](primitives.ts) – Hilfsfunktionen zum Erzeugen wiederkehrender DOM-Bausteine (Buttons, Panels, Placeholder).
+- [`stage.ts`](stage.ts) – Canvas- und Kamera-Verwaltung inklusive Pointer-Interaktionen und Element-Synchronisation.
+- [`status-banner.ts`](status-banner.ts) – Anzeige für Speichervorgänge, Fehlermeldungen und Rate-Limits.
+- [`structure-tree.ts`](structure-tree.ts) – Visualisiert die Layout-Hierarchie und hält Selektion & Fokus synchron.
+
+## Konventionen
+- **Benennung**: Komponenten-Dateien enden auf `.ts` und exportieren genau eine Klasse `SomethingComponent`. Hilfsfunktionen werden in `primitives.ts` gesammelt.
+- **Lifecycle-Hooks**: `onMount` richtet DOM-Elemente und Renderer ein, `onDestroy` räumt alle Diff-Renderer und Observer über `scope.dispose()`/`registerCleanup` auf.
+- **DiffRenderer**: Beim Einsatz von `DiffRenderer` muss `getKey` stabil bleiben; `destroy` sollte `scope.dispose()` für Kind-Komponenten aufrufen.
+- **CSS**: Komponenten erzeugen ausschließlich Klassen mit Präfix `sm-le-`. Zusätzliche Styles werden in `src/css.ts` registriert.
+- **Tests**: Änderungen an Stage, StructureTree oder DiffRenderer erfordern Begleit-Updates in `../../tests/ui-component.test.ts`, `../../tests/ui-diff-renderer.test.ts` sowie Performance-Messungen laut [`../../docs/ui-performance.md`](../../docs/ui-performance.md).
+
+## Weiterführende Dokumentation
+- Canvas- und Rendering-Details: [`../../docs/ui-performance.md`](../../docs/ui-performance.md)
+- Architektur des `src`-Moduls: [`../../LayoutEditorOverview.txt`](../../LayoutEditorOverview.txt)
+- Projektweiter Kontext: [`../../../README.md`](../../../README.md)

--- a/layout-editor/tests/README.md
+++ b/layout-editor/tests/README.md
@@ -1,0 +1,27 @@
+# Tests
+
+In diesem Ordner liegen alle automatisierten Tests für den Layout-Editor. Die Dateien werden via esbuild gebündelt und anschließend als Node-Module ausgeführt.
+
+## Inhalte
+- [`api-versioning.test.ts`](api-versioning.test.ts) – Prüft API-Level, Schema-Migrationen und Kompatibilität.
+- [`domain-configuration.test.ts`](domain-configuration.test.ts) – Validiert Domain-Source-Handling und Sicherheitsmechanismen.
+- [`history-limits.test.ts`](history-limits.test.ts) – Sicherstellt Undo/Redo-Grenzen und Snapshot-Verwaltung.
+- [`i18n-loading.test.ts`](i18n-loading.test.ts) – Prüft Übersetzungs-Ladepfade und Fallback-Strategien.
+- [`layout-editor-store.test.ts`](layout-editor-store.test.ts) – Deckt Store-Reducer, Aktionen und Selektoren ab.
+- [`layout-tree.test.ts`](layout-tree.test.ts) – Testet den Layout-Baum und Kind-Verknüpfungen.
+- [`persistence-errors.test.ts`](persistence-errors.test.ts) – Überwacht Fehlerszenarien und Banner-Anzeigen.
+- [`ui-component.test.ts`](ui-component.test.ts) – Fokus auf UIComponent-Lebenszyklus, Listener und Cleanup.
+- [`ui-diff-renderer.test.ts`](ui-diff-renderer.test.ts) – Prüft DiffRenderer-Verhalten bei Reordering und Entfernen.
+- [`view-registry.test.ts`](view-registry.test.ts) – Validiert Registrierungs-/Deregistrierungs-Guards.
+- [`run-tests.mjs`](run-tests.mjs) – Hilfsskript zum Bündeln & Ausführen der Tests (lokal).
+
+## Konventionen
+- **Dateinamen**: Alle Tests enden auf `.test.ts`. Neue Tests müssen sich an die alphabetische Sortierung halten, da `run-tests.mjs` Dateien nach Namen verarbeitet.
+- **Ausführung**: Lokal via `node ../scripts/run-tests.mjs` oder `npm test` (ruft das Skript mit Caching auf). CI verwendet dieselbe Pipeline.
+- **Test-Setup**: Test-Utilities gehören in `tests/` oder `src/utils/`. Importiere sie relativ und vermeide globale State-Leaks.
+- **Snapshots**: Statt statischer Snapshots werden Assertions bevorzugt, um Renderer-Stabilität sicherzustellen.
+
+## Weiterführende Dokumentation
+- Tooling- und Runner-Details: [`../docs/tooling.md`](../docs/tooling.md)
+- Architektur-Kontext der Module: [`../src/LayoutEditorOverview.txt`](../src/LayoutEditorOverview.txt)
+- Projektweite Nutzung & Workflows: [`../../README.md`](../../README.md)


### PR DESCRIPTION
## Summary
- document the src/ui folder responsibilities, conventions, and forward links
document the ui/components module structure, file list, and lifecycle guidelines
- add README guides for tests and scripts with execution conventions and tooling references

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d6adcd92388325812ca34ce7445d72