### PR TITLE
Standardise documentation structure and add store todo

### DIFF
--- a/Critique.txt
+++ b/Critique.txt
@@ -1,7 +1,0 @@
-# Layout Editor Plugin – Aktuelle Kritik
-
-## 1. Zustand & Datenfluss
-- **Mutierbarer Store-Snapshot:** `LayoutEditorStore.getState()` gibt die interne `state`-Instanz mit direkten Verweisen auf die `LayoutElement`-Objekte aus (`src/state/layout-editor-store.ts`, Zeilen 79–137, 326–360). UI-Schichten mutieren diese Objekte außerhalb des Stores (z. B. `StageComponent.beginMove` aktualisiert Kinderkoordinaten direkt), wodurch Undo/Redo und History-Snapshots inkonsistent werden können. Der Store benötigt unveränderliche Snapshots oder Proxies, damit externe Konsumenten keine Seiteneffekte einführen.
-
-## 2. Performance & Interaktion
-- **Stage-Interaktionen mit O(n)-Scans pro Frame:** Die Pointer-Handler der Stage greifen bei jedem Move/Resize-Event per `store.getState().elements.find(...)` auf Eltern- und Kindknoten zu (`src/ui/components/stage.ts`, Zeilen 151–206, 213–273). Diese linearen Suchen laufen pro Frame und werden zusätzlich durch direkte Kindmutationen in den gleichen Loops verstärkt. Für große Layouts führt das zu Jank und zu mehrfachen Re-Layouts. Benötigt wird ein lokaler Cache (z. B. Map auf `LayoutTree`) oder Cursor-Objekte, die ohne Vollscans und Nebenwirkungen arbeiten.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Durch Tests (`tests/api-versioning.test.ts`) wird sichergestellt, dass Legacy-La
 
 Die Tests bundlen über esbuild und führen alle `*.test.ts`-Dateien in `layout-editor/tests` aus.
 
+## Offene Aufgaben
+
+- [Layout-Store garantiert keine Seiteneffekte](todo/layout-store-consistency.md) – Tracking für die geplante Umstellung auf unveränderliche Snapshots und schnellere Stage-Cursor.
+
 ## Weiterführende Dokumentation
 
 - [`docs/api-migrations.md`](docs/api-migrations.md) – Richtlinien für API-Änderungen und Layout-Migrationen.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,3 +22,4 @@ Dieses Verzeichnis bündelt die nutzerorientierten Ergänzungen zum technischen 
 
 - Technische Detailentscheidungen findest du weiterhin direkt in den Deep-Dive-Dateien unter `layout-editor/docs/`.
 - Ergänzungen oder neue Artikel sollten hier verlinkt werden, damit Anwender:innen einen konsistenten Einstiegspunkt besitzen.
+- Offene technische Maßnahmen sind im [`../todo/`](../todo/) Verzeichnis dokumentiert und bei den jeweiligen Modulen verlinkt.

--- a/layout-editor/docs/README.md
+++ b/layout-editor/docs/README.md
@@ -17,5 +17,7 @@ related background material.
 | [Localization Guidelines](./i18n.md) | Shows how locale bundles are structured, overridden, and injected into presenters. | You add new UI strings, support additional locales, or test localisation behaviour. |
 | [Tooling](./tooling.md) | Lists linting, formatting, and test commands that enforce repository quality. | You prepare contributions or verify CI-equivalent checks locally. |
 
+Active follow-up work for the store/history stack is tracked in [`../../todo/layout-store-consistency.md`](../../todo/layout-store-consistency.md) and linked from the relevant module READMEs.
+
 For a high-level, user-facing overview of workflows and features, refer to the root
 [`docs/`](../../docs/) directory.

--- a/layout-editor/scripts/README.md
+++ b/layout-editor/scripts/README.md
@@ -14,5 +14,6 @@ Die Skripte automatisieren Build-, Test- und Generierungsaufgaben für den Layou
 
 ## Weiterführende Dokumentation
 - Tooling-Überblick & Befehle: [`../docs/tooling.md`](../docs/tooling.md)
-- Modul-Architektur und Ownership: [`../src/LayoutEditorOverview.txt`](../src/LayoutEditorOverview.txt)
+- Modul-Architektur und Ownership: [`../src/README.md`](../src/README.md)
+- Bekannte Architektur-Lücken (Store/History): [`../../todo/layout-store-consistency.md`](../../todo/layout-store-consistency.md)
 - Projektweite Nutzung & Workflows: [`../../README.md`](../../README.md)

--- a/layout-editor/src/README.md
+++ b/layout-editor/src/README.md
@@ -29,6 +29,7 @@ Der `src/`-Ordner enthält den TypeScript-Quellcode des Layout Editors. Er ist n
 
 - [`state/`](state) – Kapselt den zentralen Store.
   - [`layout-editor-store.ts`](state/layout-editor-store.ts) – Verwaltet Canvas, Elemente, Auswahl, Drag- und History-State und emittiert Änderungsereignisse.
+  - **Offene Aufgabe:** Der Store gibt derzeit veränderliche Referenzen aus und ermöglicht damit Seiteneffekte außerhalb des Stores. Details und Lösungsansätze stehen im To-Do [`../../todo/layout-store-consistency.md`](../../todo/layout-store-consistency.md).
 
 Weiterführende Details zum Datenmodell und zur Store-Architektur findest du in [`../docs/data-model-overview.md`](../docs/data-model-overview.md) und [`../docs/history-design.md`](../docs/history-design.md).
 

--- a/layout-editor/src/ui/README.md
+++ b/layout-editor/src/ui/README.md
@@ -19,6 +19,7 @@ Dieser Ordner enthält die UI-Hilfsfunktionen des Layout-Editors – insbesonder
 - **Tests**: Änderungen an UI-Hilfen erfordern Aktualisierungen in `../../tests/ui-component.test.ts` bzw. `../../tests/ui-diff-renderer.test.ts`.
 
 ## Weiterführende Dokumentation
-- Architektur-Überblick: [`../LayoutEditorOverview.txt`](../LayoutEditorOverview.txt)
+- Architektur-Überblick: [`../README.md`](../README.md)
 - Performance-Guidelines für UI-Widgets: [`../../docs/ui-performance.md`](../../docs/ui-performance.md)
+- Bekannte Optimierungsbedarfe rund um Stage-Interaktionen: [`../../../todo/layout-store-consistency.md`](../../../todo/layout-store-consistency.md)
 - Projektweite Einordnung & Workflows: [`../../../README.md`](../../../README.md)

--- a/layout-editor/src/ui/components/README.md
+++ b/layout-editor/src/ui/components/README.md
@@ -20,5 +20,6 @@ Die Komponenten in diesem Ordner implementieren die interaktiven Widgets der Can
 
 ## Weiterführende Dokumentation
 - Canvas- und Rendering-Details: [`../../docs/ui-performance.md`](../../docs/ui-performance.md)
-- Architektur des `src`-Moduls: [`../../LayoutEditorOverview.txt`](../../LayoutEditorOverview.txt)
+- Architektur des `src`-Moduls: [`../../README.md`](../../README.md)
+- Offene Performance-Optimierungen für Stage & StructureTree: [`../../../todo/layout-store-consistency.md`](../../../todo/layout-store-consistency.md)
 - Projektweiter Kontext: [`../../../README.md`](../../../README.md)

--- a/layout-editor/tests/README.md
+++ b/layout-editor/tests/README.md
@@ -23,5 +23,6 @@ In diesem Ordner liegen alle automatisierten Tests für den Layout-Editor. Die D
 
 ## Weiterführende Dokumentation
 - Tooling- und Runner-Details: [`../docs/tooling.md`](../docs/tooling.md)
-- Architektur-Kontext der Module: [`../src/LayoutEditorOverview.txt`](../src/LayoutEditorOverview.txt)
+- Architektur-Kontext der Module: [`../src/README.md`](../src/README.md)
+- Bekannte Lücken in Store/History-Tests: [`../../todo/layout-store-consistency.md`](../../todo/layout-store-consistency.md)
 - Projektweite Nutzung & Workflows: [`../../README.md`](../../README.md)

--- a/todo/README.md
+++ b/todo/README.md
@@ -1,0 +1,11 @@
+# Offene Aufgaben
+
+Dieses Verzeichnis sammelt alle offenen To-Dos für den Layout-Editor. Jede Datei beschreibt ein konkretes Thema mit Kontext, betroffenen Modulen und Lösungsideen. Sobald ein To-Do erledigt ist, wird es hier entfernt oder archiviert.
+
+## Dateien
+- [`layout-store-consistency.md`](layout-store-consistency.md) – Problemstellung rund um mutable Store-Snapshots und Stage-Performance.
+
+## Konventionen
+- **Benennung**: Dateinamen verwenden `kebab-case` und beschreiben das Thema kurz und prägnant.
+- **Struktur**: Jede Datei enthält die Abschnitte _Kontext_, _Betroffene Module_ und _Lösungsideen_.
+- **Verlinkungen**: Relevante Modul-Readmes verlinken auf die entsprechenden To-Dos, damit der Handlungsbedarf vor Ort sichtbar ist.

--- a/todo/layout-store-consistency.md
+++ b/todo/layout-store-consistency.md
@@ -1,0 +1,17 @@
+# Layout-Store garantiert keine Seiteneffekte
+
+## Kontext
+- Die aktuelle Store-Implementierung gibt in `LayoutEditorStore.getState()` direkte Referenzen auf interne `LayoutElement`-Objekte zurück.
+- UI-Schichten wie die Stage mutieren diese Referenzen außerhalb des Stores, wodurch Undo/Redo und History-Snapshots inkonsistent werden können.
+- Pointer-Handler durchsuchen bei jeder Bewegung die Elementliste linear und mutieren gleichzeitig Kinderknoten, was bei großen Layouts zu Performance-Problemen führt.
+
+## Betroffene Module
+- [`layout-editor/src/state/layout-editor-store.ts`](../layout-editor/src/state/layout-editor-store.ts)
+- [`layout-editor/src/ui/components/stage.ts`](../layout-editor/src/ui/components/stage.ts)
+- [`layout-editor/src/ui/components/structure-tree.ts`](../layout-editor/src/ui/components/structure-tree.ts) (indirekte Auswirkungen)
+
+## Lösungsideen
+- Store-API auf unveränderliche Snapshots oder Proxy-Objekte umstellen, damit externe Konsumenten nicht direkt auf den Mutations-State zugreifen können.
+- Cursor- oder Cache-Objekte einführen, um Element-Lookups ohne `O(n)`-Vollscans pro Frame zu ermöglichen.
+- History- und Undo/Redo-Fluss auf neue Snapshots ausrichten und Regressionstests in `layout-editor/tests/history-limits.test.ts` ergänzen.
+- Performance-Messungen in `layout-editor/tests/ui-diff-renderer.test.ts` erweitern, sobald der Cursor-Ansatz implementiert ist.


### PR DESCRIPTION
## Summary
- replace the loose critique text file with a structured todo entry and index under `todo/`
- update module READMEs to reference the new todo and fix broken links to the src overview
- surface the open store/history follow-up from the root README and documentation indices

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d6b4d4e6988325a08e99c6ea8f59b5