### PR TITLE
Add telemetry instrumentation for stage interactions

### DIFF
--- a/docs/stage-instrumentation.md
+++ b/docs/stage-instrumentation.md
@@ -1,0 +1,55 @@
+# Stage-Instrumentierung & Telemetrie
+
+Die Stage des Layout-Editors bündelt mehrere Interaktionspfade (Drag, Resize, Canvas-Anpassungen). Damit wir diese Abläufe
+analysieren und deterministisch testen können, stellt das State-Layer gezielte Telemetrie-Hooks bereit.
+
+## Struktur & relevante Dateien
+
+- [`layout-editor/src/state/layout-editor-store.ts`](../layout-editor/src/state/layout-editor-store.ts) – nutzt die Telemetrie-
+  Hooks an `runInteraction`, `setCanvasSize` und beim elementweisen Clamping.
+- [`layout-editor/src/state/interaction-telemetry.ts`](../layout-editor/src/state/interaction-telemetry.ts) – zentrale Sammel-
+  stelle für Observer/Logger-Konfiguration und Event-Typen.
+- [`layout-editor/tests/layout-editor-store.instrumentation.test.ts`](../layout-editor/tests/layout-editor-store.instrumentation.test.ts)
+  – überprüft Drag- und Canvas-Resize-Szenarien inklusive Clamp-Zwischenständen.
+
+## Konfiguration & Erweiterung
+
+```ts
+import {
+    setStageInteractionObserver,
+    setStageInteractionLogger,
+    resetStageInteractionTelemetry,
+    stageInteractionTelemetry,
+    type StageInteractionLogger,
+} from "layout-editor/src/state/interaction-telemetry";
+```
+
+- **Observer (`StageInteractionObserver`)**: Optionaler Hook mit speziellen Callback-Methoden (`interactionStarted`,
+  `interactionFinished`, `canvasSizeEvaluated`, `clampStepObserved`). Eignet sich für ad-hoc-Analyse im Runtime-Kontext.
+- **Logger (`StageInteractionLogger`)**: Empfängt jedes Telemetrie-Event als flachen Datensatz (`StageInteractionEvent`). Wird
+  oft als Recording-Logger in Tests genutzt.
+- **Reset (`resetStageInteractionTelemetry`)**: Setzt Observer und Logger auf No-Op zurück. Immer nach Testläufen nutzen, um
+  State-Leaks zu vermeiden.
+
+> **Hinweis:** Wird nur ein Logger gesetzt, bleiben Observer-Hooks inaktiv (No-Op). Beide Mechanismen können parallel laufen.
+
+## Event-Typen
+
+| Event                             | Auslöser                              | Felder                                                                 |
+| --------------------------------- | ------------------------------------- | ---------------------------------------------------------------------- |
+| `interaction:start`              | `runInteraction`-Entry                | `depth` – aktuelle Interaction-Tiefe                                  |
+| `interaction:end`                | `runInteraction`-Exit                 | `depth`, `hasPendingState`, `willDispatchState`, `skipExport`         |
+| `canvas:size`                    | `setCanvasSize`                       | `previous`, `requested`, `result`, `changed`                          |
+| `clamp:step`                     | Element-Clamping nach Canvas-Resize   | `elementId`, `previous`, `result`, `canvas`                           |
+
+Alle Felder sind reine JSON-kompatible Werte und können ohne weitere Serialisierung geloggt oder persistiert werden.
+
+## Tests & Qualitätssicherung
+
+Die Datei [`layout-editor-store.instrumentation.test.ts`](../layout-editor/tests/layout-editor-store.instrumentation.test.ts)
+verwendet einen Recording-Logger, um erwartete Event-Sequenzen festzuschreiben:
+
+- **Drag-Szenario** – prüft Start/Ende einer gebatchten Interaktion mit gemischten Export-Flags.
+- **Stage-Resize-Szenario** – validiert Canvas-Resize-Events und dokumentiert Clamp-Ergebnisse pro Element.
+
+Bei Erweiterungen neuer Event-Typen müssen Tests ergänzt werden, damit Sequenzen deterministisch bleiben.

--- a/layout-editor/src/state/interaction-telemetry.ts
+++ b/layout-editor/src/state/interaction-telemetry.ts
@@ -1,0 +1,110 @@
+import type { LayoutElement } from "../types";
+
+export type ElementFrameSnapshot = Pick<LayoutElement, "x" | "y" | "width" | "height">;
+
+export interface InteractionStartedEvent {
+    type: "interaction:start";
+    depth: number;
+}
+
+export interface InteractionFinishedEvent {
+    type: "interaction:end";
+    depth: number;
+    hasPendingState: boolean;
+    willDispatchState: boolean;
+    skipExport: boolean;
+}
+
+export interface CanvasSizeEvaluatedEvent {
+    type: "canvas:size";
+    previous: { width: number; height: number };
+    requested: { width: number; height: number };
+    result: { width: number; height: number };
+    changed: boolean;
+}
+
+export interface ClampStepObservedEvent {
+    type: "clamp:step";
+    elementId: string;
+    previous: ElementFrameSnapshot;
+    result: ElementFrameSnapshot;
+    canvas: { width: number; height: number };
+}
+
+export type StageInteractionEvent =
+    | InteractionStartedEvent
+    | InteractionFinishedEvent
+    | CanvasSizeEvaluatedEvent
+    | ClampStepObservedEvent;
+
+export interface StageInteractionObserver {
+    interactionStarted?(event: InteractionStartedEvent): void;
+    interactionFinished?(event: InteractionFinishedEvent): void;
+    canvasSizeEvaluated?(event: CanvasSizeEvaluatedEvent): void;
+    clampStepObserved?(event: ClampStepObservedEvent): void;
+}
+
+export interface StageInteractionLogger {
+    log(event: StageInteractionEvent): void;
+}
+
+type ObserverEventMap = {
+    interactionStarted: InteractionStartedEvent;
+    interactionFinished: InteractionFinishedEvent;
+    canvasSizeEvaluated: CanvasSizeEvaluatedEvent;
+    clampStepObserved: ClampStepObservedEvent;
+};
+
+const nullObserver: StageInteractionObserver = {};
+let activeObserver: StageInteractionObserver = nullObserver;
+let activeLogger: StageInteractionLogger | null = null;
+
+function publish<K extends keyof ObserverEventMap>(method: K, event: ObserverEventMap[K]) {
+    const handler = activeObserver[method];
+    if (typeof handler === "function") {
+        handler.call(activeObserver, event);
+    }
+    if (activeLogger) {
+        activeLogger.log(event);
+    }
+}
+
+export const stageInteractionTelemetry = {
+    interactionStarted(payload: Omit<InteractionStartedEvent, "type">) {
+        const event: InteractionStartedEvent = { type: "interaction:start", ...payload };
+        publish("interactionStarted", event);
+    },
+    interactionFinished(payload: Omit<InteractionFinishedEvent, "type">) {
+        const event: InteractionFinishedEvent = { type: "interaction:end", ...payload };
+        publish("interactionFinished", event);
+    },
+    canvasSizeEvaluated(payload: Omit<CanvasSizeEvaluatedEvent, "type">) {
+        const event: CanvasSizeEvaluatedEvent = { type: "canvas:size", ...payload };
+        publish("canvasSizeEvaluated", event);
+    },
+    clampStepObserved(payload: Omit<ClampStepObservedEvent, "type">) {
+        const event: ClampStepObservedEvent = { type: "clamp:step", ...payload };
+        publish("clampStepObserved", event);
+    },
+} as const;
+
+export function setStageInteractionObserver(observer: StageInteractionObserver | null) {
+    activeObserver = observer ?? nullObserver;
+}
+
+export function getStageInteractionObserver(): StageInteractionObserver {
+    return activeObserver;
+}
+
+export function setStageInteractionLogger(logger: StageInteractionLogger | null) {
+    activeLogger = logger;
+}
+
+export function getStageInteractionLogger(): StageInteractionLogger | null {
+    return activeLogger;
+}
+
+export function resetStageInteractionTelemetry() {
+    activeObserver = nullObserver;
+    activeLogger = null;
+}

--- a/layout-editor/tests/layout-editor-store.instrumentation.test.ts
+++ b/layout-editor/tests/layout-editor-store.instrumentation.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { LayoutEditorStore } from "../src/state/layout-editor-store";
+import {
+    resetStageInteractionTelemetry,
+    setStageInteractionLogger,
+    type StageInteractionEvent,
+    type StageInteractionLogger,
+} from "../src/state/interaction-telemetry";
+import type { LayoutElement } from "../src/types";
+
+class RecordingLogger implements StageInteractionLogger {
+    readonly events: StageInteractionEvent[] = [];
+
+    log(event: StageInteractionEvent) {
+        this.events.push(event);
+    }
+}
+
+function frameOf(element: LayoutElement) {
+    return { x: element.x, y: element.y, width: element.width, height: element.height };
+}
+
+async function runDragTelemetryScenario() {
+    resetStageInteractionTelemetry();
+    const store = new LayoutEditorStore();
+    store.createElement("label");
+    const elementId = store.getState().selectedElementId;
+    assert.ok(elementId, "drag scenario requires a selected element");
+
+    const logger = new RecordingLogger();
+    setStageInteractionLogger(logger);
+    try {
+        store.runInteraction(() => {
+            store.moveElement(elementId!, { x: 24, y: 32 }, { skipExport: true });
+            store.moveElement(elementId!, { x: 48, y: 56 });
+        });
+    } finally {
+        resetStageInteractionTelemetry();
+    }
+
+    assert.deepEqual(logger.events, [
+        { type: "interaction:start", depth: 1 },
+        {
+            type: "interaction:end",
+            depth: 1,
+            hasPendingState: true,
+            willDispatchState: true,
+            skipExport: false,
+        },
+    ]);
+}
+
+async function runStageResizeScenario() {
+    resetStageInteractionTelemetry();
+    const store = new LayoutEditorStore();
+    store.createElement("label");
+    const createdState = store.getState();
+    const element = createdState.elements.find(el => el.id === createdState.selectedElementId);
+    assert.ok(element, "resize scenario requires an element snapshot");
+    const elementId = element.id;
+
+    store.moveElement(elementId, { x: 560, y: 420 });
+    const beforeResizeState = store.getState();
+    const beforeResizeElement = beforeResizeState.elements.find(el => el.id === elementId);
+    assert.ok(beforeResizeElement, "element snapshot before resize must exist");
+    const expectedPreviousFrame = frameOf(beforeResizeElement);
+
+    const logger = new RecordingLogger();
+    setStageInteractionLogger(logger);
+    try {
+        store.setCanvasSize(360, 280);
+    } finally {
+        resetStageInteractionTelemetry();
+    }
+
+    const afterResizeState = store.getState();
+    const afterResizeElement = afterResizeState.elements.find(el => el.id === elementId);
+    assert.ok(afterResizeElement, "element snapshot after resize must exist");
+
+    assert.deepEqual(logger.events, [
+        {
+            type: "canvas:size",
+            previous: { width: 800, height: 600 },
+            requested: { width: 360, height: 280 },
+            result: { width: 360, height: 280 },
+            changed: true,
+        },
+        {
+            type: "clamp:step",
+            elementId,
+            previous: expectedPreviousFrame,
+            result: frameOf(afterResizeElement),
+            canvas: { width: 360, height: 280 },
+        },
+    ]);
+}
+
+async function runTests() {
+    await runDragTelemetryScenario();
+    await runStageResizeScenario();
+}
+
+async function run() {
+    try {
+        await runTests();
+        console.log("layout-editor-store instrumentation tests passed");
+    } catch (error) {
+        console.error(error);
+        process.exit(1);
+    }
+}
+
+run();


### PR DESCRIPTION
## Summary
- add a stage interaction telemetry module with observer/logger wiring
- emit telemetry events from the layout editor store for interactions, canvas resizing, and clamp steps
- add targeted instrumentation tests and documentation for configuring the telemetry hooks

## Testing
- npm test *(fails: missing local dependency `esbuild`)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ce6fd4348325b3a2ace367c485b2