### PR TITLE
Document telemetry instrumentation hooks in state docs

### DIFF
--- a/layout-editor/src/README.md
+++ b/layout-editor/src/README.md
@@ -29,6 +29,7 @@ Der `src/`-Ordner enthält den TypeScript-Quellcode des Layout Editors. Er ist n
 
 - [`state/`](state) – Kapselt den zentralen Store.
   - [`layout-editor-store.ts`](state/layout-editor-store.ts) – Verwaltet Canvas, Elemente, Auswahl, Drag- und History-State und emittiert Änderungsereignisse.
+  - [`interaction-telemetry.ts`](state/interaction-telemetry.ts) – Stellt Observer- und Logger-Hooks für Stage-Interaktionen bereit; Details in [`../docs/stage-instrumentation.md`](../docs/stage-instrumentation.md).
 
 Weiterführende Details zum Datenmodell und zur Store-Architektur findest du in [`../docs/data-model-overview.md`](../docs/data-model-overview.md) und [`../docs/history-design.md`](../docs/history-design.md).
 

--- a/layout-editor/src/state/README.md
+++ b/layout-editor/src/state/README.md
@@ -5,6 +5,7 @@ The state layer coordinates mutable editor state, history, and event emission. I
 ## Files
 
 - `layout-editor-store.ts` – Central store that orchestrates element CRUD, canvas sizing, selection, drag state, export payload caching, and undo/redo integration via `LayoutHistory`.
+- `interaction-telemetry.ts` – Consolidated observer/logger hub for stage interactions; exposes setters for runtime probes and the event union defined in the [stage instrumentation guide](../../docs/stage-instrumentation.md).
 
 ## Conventions & Extension Points
 
@@ -14,3 +15,4 @@ The state layer coordinates mutable editor state, history, and event emission. I
 - When expanding the public state shape, update the exported `LayoutEditorState` type and adjust serialization/restore logic. Use immutable snapshots for outward-facing state to keep observers deterministic.
 - Structural behaviour (parenting, child order, validation) is implemented in the [`model`](../model/README.md) layer. Prefer to add tree capabilities there and call them from the store.
 - For a data contract overview, refer to the [data model documentation](../../docs/data-model-overview.md). Keep store exports aligned with the documented schema so persistence and tests continue to pass.
+- Stage telemetry must be instrumented through `stageInteractionTelemetry`. Extend the `StageInteractionEvent` union and observer/logger interfaces together, keep payloads JSON-serialisable, update [`layout-editor-store.instrumentation.test.ts`](../../tests/layout-editor-store.instrumentation.test.ts), and document the new events in the [stage instrumentation guide](../../docs/stage-instrumentation.md). Always reset hooks via `resetStageInteractionTelemetry()` in tests to avoid leaks.


### PR DESCRIPTION
## Summary
- list the stage interaction telemetry module alongside the store in the src overview
- document telemetry observer/logger responsibilities and extension expectations in the state layer readme

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d7893ee22c83258431ad2ba29dc785