### PR TITLE
Document stage camera telemetry hooks

### DIFF
--- a/docs/stage-instrumentation.md
+++ b/docs/stage-instrumentation.md
@@ -44,6 +44,20 @@ import {
 
 Alle Felder sind reine JSON-kompatible Werte und können ohne weitere Serialisierung geloggt oder persistiert werden.
 
+## Kamera-Telemetrie
+
+Die Stage sendet neben Interaktions-Hooks auch Kamera-Bewegungen. Über `StageComponent.observeCamera()` können Observer für die Viewport-Lage registriert werden; die Methode liefert ein Cleanup-Lambda zurück, das den Observer wieder deregistriert und in `StageComponent.onDestroy()` automatisch ausgeführt wird. Der optionale `StageCameraObserver` kennt drei Callbacks:
+
+- **`onCenter`** – feuert, wenn die Kamera zentriert wird (Initialisierung oder Fokus auf ein Element). Das Event enthält `reason`, die aktuelle und die gewünschte Viewport-Beschreibung (`current`/`target`) sowie die Canvas-Ausmaße.
+- **`onScroll`** – reagiert auf Panning über Pointer- oder Alt+Drag-Gesten. Neben `current`/`target` werden `delta` und die `pointerId` der Interaktion mitgeliefert.
+- **`onZoom`** – liefert Zoom-Faktor, Pointer-Position im Viewport und die berechneten Welt-Koordinaten des Cursor-Fokus.
+
+Alle Events transportieren `StageCameraViewport`-Snapshots inklusive `offset`, `scale` und abgeleiteten Weltkoordinaten. Die Stage iteriert über eine Kopie der Observer-Liste, sodass sich Callbacks während eines Events sicher deregistrieren können.
+
+Der `StageController` reicht ein Telemetrie-Objekt über das `cameraTelemetry`-Feld an die Komponente weiter und verwaltet das Cleanup via Rückgabewert von `observeCamera()` in `dispose()`. Damit werden Observers zuverlässig entfernt, sobald der Controller zerstört oder der Host entkoppelt wird. Siehe die Implementierung in [`layout-editor/src/presenters/stage-controller.ts`](../layout-editor/src/presenters/stage-controller.ts) und die Observer-Definition in [`layout-editor/src/ui/components/stage.ts`](../layout-editor/src/ui/components/stage.ts).
+
+Tests in [`layout-editor/tests/stage-camera.test.ts`](../layout-editor/tests/stage-camera.test.ts) decken Initial-Centering, Scroll-, Zoom- und Fokus-Sequenzen ab und stellen sicher, dass die Telemetrie die berechneten Viewports und Deltas korrekt meldet.
+
 ## Tests & Qualitätssicherung
 
 Die Datei [`layout-editor-store.instrumentation.test.ts`](../layout-editor/tests/layout-editor-store.instrumentation.test.ts)

--- a/layout-editor/docs/ui-performance.md
+++ b/layout-editor/docs/ui-performance.md
@@ -16,6 +16,7 @@ The component layer now renders through a lightweight diffing helper that keeps 
 - Element-specific listeners (pointer move/leave/down) register on the per-node scope. When an element disappears, its interaction listeners disappear with it, preventing leaks between sessions.
 - Drag interactions run inside `LayoutEditorStore.runInteraction()`. The store batches `move`/`resize` plus layout reflows into a single state emission per frame, so the DOM stays in sync without flooding listeners.
 - Drag interactions now call `LayoutEditorStore.flushExport()` once the pointer is released. During the drag, frame updates emit only `state` events, batching export payloads until the interaction settles so JSON serialization does not run on every frame.
+- Camera motions emit `StageCameraObserver` telemetry hooks. Register them through `StageController` and clean them up as described in [Stage instrumentation › Kamera-Telemetrie](../../docs/stage-instrumentation.md#kamera-telemetrie).
 
 ## Structure tree component
 

--- a/layout-editor/src/ui/components/README.md
+++ b/layout-editor/src/ui/components/README.md
@@ -7,7 +7,7 @@ Die Komponenten in diesem Ordner implementieren die interaktiven Widgets der Can
 - [`diff-renderer.ts`](diff-renderer.ts) – Leichtgewichtiger Renderer, der auf Key-basierten Diffs DOM-Bäume patcht.
 - [`editor-shell.ts`](editor-shell.ts) – Umschließender Rahmen für Toolbar, Stage und Inspector.
 - [`primitives.ts`](primitives.ts) – Hilfsfunktionen zum Erzeugen wiederkehrender DOM-Bausteine (Buttons, Panels, Placeholder).
-- [`stage.ts`](stage.ts) – Canvas- und Kamera-Verwaltung inklusive Pointer-Interaktionen und Element-Synchronisation.
+- [`stage.ts`](stage.ts) – Canvas- und Kamera-Verwaltung inklusive Pointer-Interaktionen und Element-Synchronisation; Kamera-Hooks siehe [Stage-Instrumentierung › Kamera-Telemetrie](../../../docs/stage-instrumentation.md#kamera-telemetrie).
 - [`status-banner.ts`](status-banner.ts) – Anzeige für Speichervorgänge, Fehlermeldungen und Rate-Limits.
 - [`structure-tree.ts`](structure-tree.ts) – Visualisiert die Layout-Hierarchie und hält Selektion & Fokus synchron.
 


### PR DESCRIPTION
## Summary
- document StageCameraObserver lifecycle, events, and StageController cleanup in the stage instrumentation guide
- link the camera telemetry section from the UI performance overview and component catalog

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d7893c538c83258f66c7532d6afe68