### PR TITLE
Document DiffRenderer cleanup audit

### DIFF
--- a/layout-editor/src/ui/components/README.md
+++ b/layout-editor/src/ui/components/README.md
@@ -12,6 +12,7 @@ Die Komponenten in diesem Ordner implementieren die interaktiven Widgets der Can
 - [`structure-tree.ts`](structure-tree.ts) – Visualisiert die Layout-Hierarchie und hält Selektion & Fokus synchron.
 
 ## Konventionen
+- **To-Do**: [Dokumentationsabgleich](../../../todo/ui-components-doc-audit.md)
 - **Benennung**: Komponenten-Dateien enden auf `.ts` und exportieren genau eine Klasse `SomethingComponent`. Hilfsfunktionen werden in `primitives.ts` gesammelt.
 - **Lifecycle-Hooks**: `onMount` richtet DOM-Elemente und Renderer ein, `onDestroy` räumt alle Diff-Renderer und Observer über `scope.dispose()`/`registerCleanup` auf.
 - **DiffRenderer**: Beim Einsatz von `DiffRenderer` muss `getKey` stabil bleiben; `destroy` sollte `scope.dispose()` für Kind-Komponenten aufrufen.

--- a/todo/ui-components-doc-audit.md
+++ b/todo/ui-components-doc-audit.md
@@ -1,0 +1,15 @@
+# UI-Komponenten Doku-Audit
+
+## Originalkritik
+- Die Konventionen im Komponenten-README verlangen weiterhin, dass `DiffRenderer`-Hooks `scope.dispose()` manuell aufrufen. Die aktuelle Implementierung von `DiffRenderer` erledigt das selbst nach `destroy()`, wodurch die Dokumentation veraltet ist und unnötige bzw. doppelte Cleanups begünstigt.
+
+## Kontext
+- `DiffRenderer.patch()` ruft nach dem optionalen `destroy`-Hook immer `entry.scope.dispose()` auf. Zusätzliche Aufräumaufrufe würden doppelte Disposables auslösen. Die Stage- und Structure-Tree-Komponenten folgen bereits diesem Muster und übergeben nur Aufräumlogik, die den DOM-Cache aktualisiert.
+- Die Dokumentation zu Pointer-Caching und Telemetrie-Hooks ist konsistent mit dem Ist-Zustand: `StageComponent` pflegt einen `elementCursorCache` je Snapshot und feuert `StageCameraObserver`-Events für Scroll-, Zoom- und Center-Aktionen.
+
+## Betroffene Module
+- `layout-editor/src/ui/components/README.md`
+
+## Lösungsideen
+- Konventionsabschnitt im Komponenten-README aktualisieren: klarstellen, dass `DiffRenderer` selbst `scope.dispose()` übernimmt und der `destroy`-Hook sich auf komponentenspezifische Aufräumarbeiten beschränken soll.
+- Im selben Zug auf den Funktionsumfang des Scopes hinweisen (`context.scope.listen`/`register`), damit Integratoren erkennen, wie untergeordnete Komponenten sauber angebunden werden.


### PR DESCRIPTION
## Summary
- add a documentation audit to-do capturing the outdated DiffRenderer cleanup guidance
- link the UI components README conventions section to the new planning note

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d78c9998c083259c244ec8afed155c