### PR TITLE
Document tooling audit findings

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,3 +25,4 @@ Dieses Verzeichnis bündelt die nutzerorientierten Ergänzungen zum technischen 
 - Technische Detailentscheidungen findest du weiterhin direkt in den Deep-Dive-Dateien unter `layout-editor/docs/`.
 - Ergänzungen oder neue Artikel sollten hier verlinkt werden, damit Anwender:innen einen konsistenten Einstiegspunkt besitzen.
 - Offene technische Maßnahmen sind im [`../todo/`](../todo/) Verzeichnis dokumentiert und bei den jeweiligen Modulen verlinkt.
+- Strukturabgleich & Nachbesserungen: siehe [`../todo/tooling-doc-audit.md`](../todo/tooling-doc-audit.md).

--- a/layout-editor/docs/tooling.md
+++ b/layout-editor/docs/tooling.md
@@ -22,3 +22,7 @@ Add new test files under `tests/` using the `*.test.ts` naming convention to hav
 
 - [Documentation index](./README.md)
 - Related: [Plugin API](./plugin-api.md)
+
+## Offene Aufgaben
+
+- Abgleich der Tooling-Dokumentation: siehe [`../../todo/tooling-doc-audit.md`](../../todo/tooling-doc-audit.md).

--- a/layout-editor/tests/README.md
+++ b/layout-editor/tests/README.md
@@ -33,3 +33,4 @@ In diesem Ordner liegen alle automatisierten Tests für den Layout-Editor. Die D
 ## To-Do
 
 - Tests prüfen, dass Store-Snapshots außerhalb des Stores nicht mutierbar sind. Neue Cases gehören in `layout-editor-store.test.ts` und `history-limits.test.ts`.
+- Struktur- und Dokumentationsabgleich: siehe [`../../todo/tooling-doc-audit.md`](../../todo/tooling-doc-audit.md).

--- a/todo/tooling-doc-audit.md
+++ b/todo/tooling-doc-audit.md
@@ -1,0 +1,18 @@
+# Tooling-Dokumentationsabgleich
+
+## Originalkritik
+- `docs/README.md` listet nur `api-migrations.md` im Verzeichnis `docs/`, obwohl `persistence-diagnostics.md` und `stage-instrumentation.md` dort ebenfalls liegen.
+- Derselbe Index verlinkt auf `layout-editor/docs/persistence-diagnostics.md`, diese Datei existiert nicht; die Diagnose-Dokumentation befindet sich im Wurzel-`docs/`-Ordner.
+- `layout-editor/tests/README.md` erwähnt den Ordner `helpers/` nicht, der als gemeinsames Test-Hilfsverzeichnis geführt wird, wodurch die Strukturübersicht lückenhaft bleibt.
+
+## Kontext
+- Abgleich der Test-, Tooling- und Benutzer-Dokumentation mit dem aktuellen Repository-Zustand im Rahmen des Tooling-Dokumentationsaudits.
+- Fokus auf Strukturangaben und Dateiverweise, ohne inhaltliche Aktualisierung der beschriebenen Workflows.
+
+## Betroffene Module
+- `docs/README.md`
+- `layout-editor/tests/README.md`
+
+## Lösungsideen
+- Ergänze `docs/README.md` um die fehlenden Dateien im Abschnitt „Dateien in `docs/`“ und korrigiere den fehlerhaften Verweis auf die Diagnose-Dokumentation.
+- Beschreibe den Ordner `helpers/` in `layout-editor/tests/README.md`, inklusive Zweck (z. B. geteilte Fixtures), damit neue Beiträge die Struktur nachvollziehen können.


### PR DESCRIPTION
## Summary
- add a dedicated tooling documentation audit to-do capturing gaps in the docs and test index
- link the affected test, tooling, and user documentation pages back to the new audit entry for visibility

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d78c9da3b08325ab5f5a95758c3b4f