### PR TITLE
Add audit for plugin shell documentation gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Die Tests bundlen über esbuild und führen alle `*.test.ts`-Dateien in `layout-
 
 ## To-Do
 
+- [Plugin-Shell-Dokumentationsaudit](todo/plugin-shell-doc-audit.md)
 
 ## Weiterführende Dokumentation
 

--- a/layout-editor/src/README.md
+++ b/layout-editor/src/README.md
@@ -24,6 +24,7 @@ Der `src/`-Ordner enthält den TypeScript-Quellcode des Layout Editors. Er ist n
 - [`search-dropdown.ts`](search-dropdown.ts) – Autocomplete-Helfer für Eingabefelder.
 - [`seed-layouts.ts`](seed-layouts.ts) – Legt Standard-Layouts beim ersten Start an.
 - [`elements/ui.ts`](elements/ui.ts) – UI-Helfer (Buttons, Inputs, Statusanzeigen) für View und Modals.
+- [`To-Do: Plugin-Shell-Dokumentationsaudit`](../../todo/plugin-shell-doc-audit.md) – Tracking der Diskrepanzen zwischen dokumentierter Shell-API und tatsächlichen Exports.
 
 ## Zustandsverwaltung
 

--- a/todo/plugin-shell-doc-audit.md
+++ b/todo/plugin-shell-doc-audit.md
@@ -1,0 +1,23 @@
+# Plugin-Shell-Dokumentationsaudit
+
+## Originalkritik
+
+- Die Dokumentation zur View-Registry verheißt zusätzliche Diagnose-Helfer (`getViewBinding`, `hasViewBinding`, `getViewBindingIds`, `getViewBindingsByTag`) als Teil der öffentlich importierbaren API. Der tatsächlich ausgelieferte Einstiegspunkt (Plugin-API sowie `index.ts`-Re-Exports) stellt diese Diagnosefunktionen nur teilweise bereit.
+
+## Kontext
+
+- `layout-editor/docs/view-registry.md` listet die genannten Helfer im Abschnitt „Abfragen & Diagnose“ als verfügbaren Teil der importierbaren Registry-API, inklusive der Aussage, dass der bestehende API-Umfang unverändert bleibt.
+- Das in `layout-editor/src/main.ts` definierte `LayoutEditorPluginApi`-Objekt liefert jedoch ausschließlich `getViewBindings` und `onViewBindingsChanged` neben den Mutationsfunktionen; weitere Diagnose-Helfer fehlen vollständig.
+- `layout-editor/src/index.ts` exportiert zwar `getViewBinding`, lässt aber `hasViewBinding`, `getViewBindingIds` und `getViewBindingsByTag` aus, womit auch direkte Modulimporte keinen dokumentationskonformen Umfang erhalten.
+
+## Betroffene Module
+
+- `layout-editor/docs/view-registry.md`
+- `layout-editor/src/main.ts`
+- `layout-editor/src/index.ts`
+
+## Lösungsideen
+
+- Öffentliche API und Re-Exports erweitern, sodass die dokumentierten Diagnosefunktionen tatsächlich verfügbar sind (inklusive Typdefinitionen und Tests für das Paket-Bundle).
+- Alternativ die Dokumentation auf den realen Funktionsumfang zurückschneiden und klarstellen, dass weitergehende Diagnosen derzeit nicht über den Einstiegspunkt erreichbar sind.
+- In beiden Fällen die User-Dokumentation und etwaige Workflows aktualisieren, damit Konsumenten verlässliche Hinweise für Shell-/Registry-Integrationen erhalten.


### PR DESCRIPTION
## Summary
- add a dedicated to-do to capture discrepancies between the documented shell entry-point and the shipped API
- surface the new audit note from the root and src readmes for discoverability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d78c92e5948325b5ef7aaad4b61e3a