### PR TITLE
Add audit note for domain toggle seed sync documentation

### DIFF
--- a/layout-editor/docs/domain-configuration.md
+++ b/layout-editor/docs/domain-configuration.md
@@ -4,6 +4,8 @@ Die Layout-Definitionen des Plugins lassen sich jetzt entweder aus den eingebaut
 oder aus einer JSON-Datei im Vault laden. Diese Seite beschreibt Aufbau, Ablageort und
 Validierungsregeln der Konfiguration sowie die notwendigen Schritte zur Aktivierung.
 
+> **To-Do:** [Audit der Persistenz-, Konfigurations- & i18n-Dokumentation](../../todo/persistence-config-i18n-doc-audit.md)
+
 ## Quellen auswählen
 
 1. Öffne die **Einstellungen** von Obsidian und navigiere zu **Community Plugins → Layout Editor**.

--- a/layout-editor/docs/layout-library.md
+++ b/layout-editor/docs/layout-library.md
@@ -2,6 +2,8 @@
 
 Die Layout-Bibliothek kapselt das Speichern und Laden von Layout-Dateien im Obsidian-Vault. Dieses Dokument beschreibt die Ordnerstruktur, ID- und Schema-Regeln sowie die Fehlerbehandlung des Moduls `src/layout-library.ts`.
 
+> **To-Do:** [Audit der Persistenz-, Konfigurations- & i18n-Dokumentation](../../todo/persistence-config-i18n-doc-audit.md)
+
 ## Vault-Pfade und Legacy-Verzeichnisse
 
 - **Aktueller Speicherort:** Layouts werden standardmäßig unter `LayoutEditor/Layouts` abgelegt. Das Modul legt fehlende Ordner automatisch an, indem es die Segmente nacheinander erzeugt.【F:layout-editor/src/layout-library.ts†L28-L131】

--- a/layout-editor/docs/persistence-errors.md
+++ b/layout-editor/docs/persistence-errors.md
@@ -4,6 +4,8 @@ Der Header des Layout-Editors blendet bei fehlgeschlagenen Speicheroperationen e
 stellt strukturierte Informationen dar, damit Anwender den Fehler ohne Konsole nachvollziehen können. Technische Hintergründe
 zu Vault-Pfaden, Schema-Regeln und Fehlerquellen liefert [`layout-library.md`](./layout-library.md).
 
+> **To-Do:** [Audit der Persistenz-, Konfigurations- & i18n-Dokumentation](../../todo/persistence-config-i18n-doc-audit.md)
+
 ## Verhalten
 
 - **Auslöser:** Fehler des `layout-library`-Moduls, z. B. ungültige IDs oder Elementdaten beim Speichern.

--- a/layout-editor/src/config/README.md
+++ b/layout-editor/src/config/README.md
@@ -2,6 +2,8 @@
 
 Configuration sources define how the editor loads domain-specific element metadata, attribute groups, and seed layouts. The logic here resolves the active configuration, validates incoming payloads, and exposes defaults for callers that need deterministic fallback data.
 
+> **To-Do:** [Audit der Persistenz-, Konfigurations- & i18n-Dokumentation](../../../todo/persistence-config-i18n-doc-audit.md)
+
 ## Files
 
 - `domain-source.ts` – Loads the configured domain bundle (builtin or vault JSON), validates payloads, exposes helper types for seed layouts, and emits descriptive errors when configuration is invalid.

--- a/layout-editor/src/i18n/README.md
+++ b/layout-editor/src/i18n/README.md
@@ -2,6 +2,8 @@
 
 The localisation layer bundles all human-facing strings for the layout editor and provides helpers to clone and extend the default German translations.
 
+> **To-Do:** [Audit der Persistenz-, Konfigurations- & i18n-Dokumentation](../../../todo/persistence-config-i18n-doc-audit.md)
+
 ## Files
 
 - `strings.ts` – Declares the locale schema, exposes `createLayoutEditorStrings` for deep-merging overrides, and implements formatting helpers such as `formatLayoutString`.

--- a/layout-editor/src/settings/README.md
+++ b/layout-editor/src/settings/README.md
@@ -2,6 +2,8 @@
 
 Settings modules integrate the layout editor with Obsidian's preferences UI and expose runtime toggles that affect configuration sources and editor behaviour.
 
+> **To-Do:** [Audit der Persistenz-, Konfigurations- & i18n-Dokumentation](../../../todo/persistence-config-i18n-doc-audit.md)
+
 ## Files
 
 - `domain-settings.ts` – Manages the active domain configuration source, persists the selection in `localStorage`, notifies listeners about changes, and renders the toggle control used in the settings tab.

--- a/todo/persistence-config-i18n-doc-audit.md
+++ b/todo/persistence-config-i18n-doc-audit.md
@@ -1,0 +1,16 @@
+# Persistenz-, Konfigurations- & i18n-Doku Audit
+
+## Originalkritik
+- `docs/domain-configuration.md` verspricht, dass beim Umschalten der Domänenquelle sowohl Element-Definitionen als auch Seed-Layouts sofort aktualisiert werden. Die Implementierung lädt die neue Konfiguration zwar in `domainConfigurationService`, triggert aber keinen erneuten Seed-Sync; `ensureSeedLayouts` wird ausschließlich während `LayoutEditorPlugin.onload` aufgerufen. Dadurch bleiben Vault-Seeds nach einem Toggle unverändert.【F:layout-editor/docs/domain-configuration.md†L11-L17】【F:layout-editor/src/config/domain-source.ts†L935-L991】【F:layout-editor/src/main.ts†L116-L133】【F:layout-editor/src/seed-layouts.ts†L150-L209】
+
+## Kontext
+- Audit der Dokumente `layout-library.md`, `domain-configuration.md`, `persistence-errors.md` sowie der Modul-Readmes unter `src/config/`, `src/settings/` und `src/i18n/` gegen die aktuellen Seed-Flows, die Domänen-Toggle-Implementierung, Validierungsregeln und Lokalisierungs-Helper.
+- Die Layout-Bibliothek, Persistenzfehler- und i18n-Dokumente beschreiben den aktuellen Stand korrekt; Handlungsbedarf besteht nur im Zusammenspiel zwischen Toggle-Dokumentation und Seed-Synchronisation.
+
+## Betroffene Module
+- Dokumentation: `layout-editor/docs/domain-configuration.md`.
+- Laufzeitlogik: `layout-editor/src/config/domain-source.ts`, `layout-editor/src/seed-layouts.ts`, `layout-editor/src/main.ts`.
+
+## Lösungsideen
+- Dokumentation anpassen, um klarzustellen, dass Seed-Layouts nach einem Toggle nicht automatisch geschrieben werden, oder
+- Implementierung erweitern (z. B. `onDomainConfigurationSourceChange` → `ensureSeedLayouts`), damit der beschriebene Workflow stimmt; dabei Konflikte und Idempotenz der Seeds berücksichtigen.


### PR DESCRIPTION
## Summary
- add a todo audit describing the mismatch between the documented domain-source toggle behaviour and the current seed sync implementation
- link the relevant persistence, configuration, settings, and i18n docs back to the new audit for follow-up coordination

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d78c9be1f48325a71c52b1f28769e0