### PR TITLE
Fix user docs index and telemetry cross-links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,11 @@
 
 Dieses Verzeichnis bündelt die nutzerorientierten Ergänzungen zum technischen Wiki im Ordner [`layout-editor/docs/`](../layout-editor/docs/). Hier findest du Schritt-für-Schritt-Anleitungen, Migrationshinweise und Querverweise, damit du den Layout-Editor sicher einsetzen kannst.
 
-## Dateien in `docs/`
+## Struktur & Dateien in `docs/`
 
 - [`api-migrations.md`](api-migrations.md) – Leitfaden für API-Änderungen, Layout-Schema-Migrationen sowie Qualitätschecks rund um Versionssprünge.
+- [`persistence-diagnostics.md`](persistence-diagnostics.md) – Monitoring-Checks und Leitplanken für Speicherintegrität im Clusterbetrieb.
+- [`stage-instrumentation.md`](stage-instrumentation.md) – Messpunkte, KPIs und Alarmierungs-Setup für Deploy- und Preview-Stages.
 
 ## Verwandte Deep-Dives in `layout-editor/docs/`
 
@@ -12,10 +14,8 @@ Dieses Verzeichnis bündelt die nutzerorientierten Ergänzungen zum technischen 
 - [`layout-library.md`](../layout-editor/docs/layout-library.md) – Nutzung der Layout-Bibliothek, Persistenzregeln und Wiederherstellungsabläufe.
 - [`data-model-overview.md`](../layout-editor/docs/data-model-overview.md) – Überblick über Layout-Entities, Beziehungen und Schemafelder.
 - [`persistence-errors.md`](../layout-editor/docs/persistence-errors.md) – Fehlermeldungen und Troubleshooting bei Speichern & Laden.
-- [`persistence-diagnostics.md`](../layout-editor/docs/persistence-diagnostics.md) – Monitoring-Checks und Leitplanken für Speicherintegrität im Clusterbetrieb.
 - [`ui-performance.md`](../layout-editor/docs/ui-performance.md) – Optimierung von Rendering, Diffs und Interaktionen für große Layouts.
 - [`i18n.md`](../layout-editor/docs/i18n.md) – Lokalisierung und Übersetzungs-Workflow im Layout-Editor.
-- [`stage-instrumentation.md`](../layout-editor/docs/stage-instrumentation.md) – Messpunkte, KPIs und Alarmierungs-Setup für Deploy- und Preview-Stages.
 - [`view-registry.md`](../layout-editor/docs/view-registry.md) – Lebenszyklus und Schutzmechanismen der View-Registry.
 - [`domain-configuration.md`](../layout-editor/docs/domain-configuration.md) – Konfiguration von Datenquellen und Sicherheitsmechanismen.
 - [`tooling.md`](../layout-editor/docs/tooling.md) – CLI-Helfer, Tests und Automatisierungen für Entwickler:innen.

--- a/layout-editor/src/README.md
+++ b/layout-editor/src/README.md
@@ -30,7 +30,7 @@ Der `src/`-Ordner enthält den TypeScript-Quellcode des Layout Editors. Er ist n
 
 - [`state/`](state) – Kapselt den zentralen Store.
   - [`layout-editor-store.ts`](state/layout-editor-store.ts) – Verwaltet Canvas, Elemente, Auswahl, Drag- und History-State und emittiert Änderungsereignisse.
-  - [`interaction-telemetry.ts`](state/interaction-telemetry.ts) – Stellt Observer- und Logger-Hooks für Stage-Interaktionen bereit; Details in [`../docs/stage-instrumentation.md`](../docs/stage-instrumentation.md).
+  - [`interaction-telemetry.ts`](state/interaction-telemetry.ts) – Stellt Observer- und Logger-Hooks für Stage-Interaktionen bereit; Details in [`../../docs/stage-instrumentation.md`](../../docs/stage-instrumentation.md).
 
 Weiterführende Details zum Datenmodell und zur Store-Architektur findest du in [`../docs/data-model-overview.md`](../docs/data-model-overview.md) und [`../docs/history-design.md`](../docs/history-design.md).
 

--- a/layout-editor/src/state/README.md
+++ b/layout-editor/src/state/README.md
@@ -5,7 +5,7 @@ The state layer coordinates mutable editor state, history, and event emission. I
 ## Files
 
 - `layout-editor-store.ts` – Central store that orchestrates element CRUD, canvas sizing, selection, drag state, export payload caching, and undo/redo integration via `LayoutHistory`.
-- `interaction-telemetry.ts` – Consolidated observer/logger hub for stage interactions; exposes setters for runtime probes and the event union defined in the [stage instrumentation guide](../../docs/stage-instrumentation.md).
+- `interaction-telemetry.ts` – Consolidated observer/logger hub for stage interactions; exposes setters for runtime probes and the event union defined in the [stage instrumentation guide](../../../docs/stage-instrumentation.md).
 
 ## Conventions & Extension Points
 
@@ -15,7 +15,7 @@ The state layer coordinates mutable editor state, history, and event emission. I
 - When expanding the public state shape, update the exported `LayoutEditorState` type and adjust serialization/restore logic. Use immutable snapshots for outward-facing state to keep observers deterministic.
 - Structural behaviour (parenting, child order, validation) is implemented in the [`model`](../model/README.md) layer. Prefer to add tree capabilities there and call them from the store.
 - For a data contract overview, refer to the [data model documentation](../../docs/data-model-overview.md). Keep store exports aligned with the documented schema so persistence and tests continue to pass.
-- Stage telemetry must be instrumented through `stageInteractionTelemetry`. Extend the `StageInteractionEvent` union and observer/logger interfaces together, keep payloads JSON-serialisable, update [`layout-editor-store.instrumentation.test.ts`](../../tests/layout-editor-store.instrumentation.test.ts), and document the new events in the [stage instrumentation guide](../../docs/stage-instrumentation.md). Always reset hooks via `resetStageInteractionTelemetry()` in tests to avoid leaks.
+- Stage telemetry must be instrumented through `stageInteractionTelemetry`. Extend the `StageInteractionEvent` union and observer/logger interfaces together, keep payloads JSON-serialisable, update [`layout-editor-store.instrumentation.test.ts`](../../tests/layout-editor-store.instrumentation.test.ts), and document the new events in the [stage instrumentation guide](../../../docs/stage-instrumentation.md). Always reset hooks via `resetStageInteractionTelemetry()` in tests to avoid leaks.
 
 ## To-Do
 

--- a/layout-editor/src/ui/components/README.md
+++ b/layout-editor/src/ui/components/README.md
@@ -7,7 +7,7 @@ Die Komponenten in diesem Ordner implementieren die interaktiven Widgets der Can
 - [`diff-renderer.ts`](diff-renderer.ts) – Leichtgewichtiger Renderer, der auf Key-basierten Diffs DOM-Bäume patcht.
 - [`editor-shell.ts`](editor-shell.ts) – Umschließender Rahmen für Toolbar, Stage und Inspector.
 - [`primitives.ts`](primitives.ts) – Hilfsfunktionen zum Erzeugen wiederkehrender DOM-Bausteine (Buttons, Panels, Placeholder).
-- [`stage.ts`](stage.ts) – Canvas- und Kamera-Verwaltung inklusive Pointer-Interaktionen und Element-Synchronisation; Kamera-Hooks siehe [Stage-Instrumentierung › Kamera-Telemetrie](../../../docs/stage-instrumentation.md#kamera-telemetrie).
+- [`stage.ts`](stage.ts) – Canvas- und Kamera-Verwaltung inklusive Pointer-Interaktionen und Element-Synchronisation; Kamera-Hooks siehe [Stage-Instrumentierung › Kamera-Telemetrie](../../../../docs/stage-instrumentation.md#kamera-telemetrie).
 - [`status-banner.ts`](status-banner.ts) – Anzeige für Speichervorgänge, Fehlermeldungen und Rate-Limits.
 - [`structure-tree.ts`](structure-tree.ts) – Visualisiert die Layout-Hierarchie und hält Selektion & Fokus synchron.
 

--- a/layout-editor/tests/README.md
+++ b/layout-editor/tests/README.md
@@ -3,20 +3,23 @@
 In diesem Ordner liegen alle automatisierten Tests für den Layout-Editor. Die Dateien werden via esbuild gebündelt und anschließend als Node-Module ausgeführt.
 
 ## Inhalte
-- [`api-versioning.test.ts`](api-versioning.test.ts) – Prüft API-Level, Schema-Migrationen und Kompatibilität.
-- [`container-relayout.test.ts`](container-relayout.test.ts) – Prüft stilles Relayout bei Drag- und Resize-Szenarien über alle Container-Varianten.
-- [`domain-configuration.test.ts`](domain-configuration.test.ts) – Validiert Domain-Source-Handling und Sicherheitsmechanismen.
-- [`history-limits.test.ts`](history-limits.test.ts) – Sicherstellt Undo/Redo-Grenzen und Snapshot-Verwaltung.
-- [`i18n-loading.test.ts`](i18n-loading.test.ts) – Prüft Übersetzungs-Ladepfade und Fallback-Strategien.
-- [`layout-editor-store.test.ts`](layout-editor-store.test.ts) – Deckt Store-Reducer, Aktionen und Selektoren ab.
-- [`layout-editor-store.instrumentation.test.ts`](layout-editor-store.instrumentation.test.ts) – Überwacht Stage-Interaktions-Telemetrie für Bewegungen, Canvas-Resize und Clamping.
-- [`layout-tree.test.ts`](layout-tree.test.ts) – Testet den Layout-Baum und Kind-Verknüpfungen.
-- [`persistence-errors.test.ts`](persistence-errors.test.ts) – Überwacht Fehlerszenarien und Banner-Anzeigen.
-- [`stage-camera.test.ts`](stage-camera.test.ts) – Stellt sicher, dass StageController-Zentrierung, Scrollen, Zoomen und Fokusereignisse Telemetrie korrekt melden.
-- [`stage-component.test.ts`](stage-component.test.ts) – Simuliert Stage-Drags mit mehreren Elementen und prüft Cursor-Caches sowie gebatchte Store-Updates.
-- [`ui-component.test.ts`](ui-component.test.ts) – Fokus auf UIComponent-Lebenszyklus, Listener und Cleanup.
-- [`ui-diff-renderer.test.ts`](ui-diff-renderer.test.ts) – Prüft DiffRenderer-Verhalten bei Reordering und Entfernen.
-- [`view-registry.test.ts`](view-registry.test.ts) – Validiert Registrierungs-/Deregistrierungs-Guards.
+- [`helpers/`](helpers) – Gemeinsame Fixtures und Utilities für Tests.
+  - [`container-fixtures.ts`](helpers/container-fixtures.ts) – Stellt vorkonfigurierte Container-Bäume und Drag-Szenarien für Stage- und Store-Tests bereit.
+- **Testdateien (alphabetisch)**
+  - [`api-versioning.test.ts`](api-versioning.test.ts) – Prüft API-Level, Schema-Migrationen und Kompatibilität.
+  - [`container-relayout.test.ts`](container-relayout.test.ts) – Prüft stilles Relayout bei Drag- und Resize-Szenarien über alle Container-Varianten.
+  - [`domain-configuration.test.ts`](domain-configuration.test.ts) – Validiert Domain-Source-Handling und Sicherheitsmechanismen.
+  - [`history-limits.test.ts`](history-limits.test.ts) – Sicherstellt Undo/Redo-Grenzen und Snapshot-Verwaltung.
+  - [`i18n-loading.test.ts`](i18n-loading.test.ts) – Prüft Übersetzungs-Ladepfade und Fallback-Strategien.
+  - [`layout-editor-store.instrumentation.test.ts`](layout-editor-store.instrumentation.test.ts) – Überwacht Stage-Interaktions-Telemetrie für Bewegungen, Canvas-Resize und Clamping.
+  - [`layout-editor-store.test.ts`](layout-editor-store.test.ts) – Deckt Store-Reducer, Aktionen und Selektoren ab.
+  - [`layout-tree.test.ts`](layout-tree.test.ts) – Testet den Layout-Baum und Kind-Verknüpfungen.
+  - [`persistence-errors.test.ts`](persistence-errors.test.ts) – Überwacht Fehlerszenarien und Banner-Anzeigen.
+  - [`stage-camera.test.ts`](stage-camera.test.ts) – Stellt sicher, dass StageController-Zentrierung, Scrollen, Zoomen und Fokusereignisse Telemetrie korrekt melden.
+  - [`stage-component.test.ts`](stage-component.test.ts) – Simuliert Stage-Drags mit mehreren Elementen und prüft Cursor-Caches sowie gebatchte Store-Updates.
+  - [`ui-component.test.ts`](ui-component.test.ts) – Fokus auf UIComponent-Lebenszyklus, Listener und Cleanup.
+  - [`ui-diff-renderer.test.ts`](ui-diff-renderer.test.ts) – Prüft DiffRenderer-Verhalten bei Reordering und Entfernen.
+  - [`view-registry.test.ts`](view-registry.test.ts) – Validiert Registrierungs-/Deregistrierungs-Guards.
 - [`run-tests.mjs`](run-tests.mjs) – Hilfsskript zum Bündeln & Ausführen der Tests (lokal).
 
 ## Konventionen

--- a/todo/state-model-doc-audit.md
+++ b/todo/state-model-doc-audit.md
@@ -12,17 +12,17 @@ tags:
 # State/model documentation audit
 
 ## Originalkritik
-- Das State-README verweist auf einen nicht mehr existierenden "stage instrumentation"-Guide, wodurch Telemetrie-Konventionen nirgendwo verbindlich dokumentiert sind.
+- Das State-README verweist auf einen "stage instrumentation"-Guide, dessen gültiger Speicherort (`docs/stage-instrumentation.md`) konsistent nachgezogen werden muss, damit Telemetrie-Konventionen verbindlich dokumentiert bleiben.
 - Die Store-Dokumentation beschreibt Telemetrie-Ereignisse nur implizit; ohne zentrale Referenz droht Drift zwischen `stageInteractionTelemetry` und künftigen Erweiterungen.
 
 ## Kontext
-Die Telemetrie-Pipeline (`stageInteractionTelemetry` in `layout-editor/src/state/interaction-telemetry.ts`) emittiert Ereignisse wie `interaction:start`, `interaction:end`, `canvas:size` und `clamp:step`. Das State-README fordert weiterhin, neue Events im nicht vorhandenen `layout-editor/docs/stage-instrumentation.md` zu dokumentieren. Gleichzeitig hängt die Konsistenz von Snapshot-Emissionen und Export-Payloads an `cloneLayoutElement`; ohne eine aktualisierte Referenz fällt die Abstimmung zwischen Store-, Modell- und Analytics-Teams schwer.
+Die Telemetrie-Pipeline (`stageInteractionTelemetry` in `layout-editor/src/state/interaction-telemetry.ts`) emittiert Ereignisse wie `interaction:start`, `interaction:end`, `canvas:size` und `clamp:step`. Das State-README forderte bislang, neue Events im nicht vorhandenen `layout-editor/docs/stage-instrumentation.md` zu dokumentieren; der Guide liegt faktisch unter [`docs/stage-instrumentation.md`](../docs/stage-instrumentation.md). Gleichzeitig hängt die Konsistenz von Snapshot-Emissionen und Export-Payloads an `cloneLayoutElement`; ohne eine aktualisierte Referenz fällt die Abstimmung zwischen Store-, Modell- und Analytics-Teams schwer.
 
 ## Betroffene Module
 - `layout-editor/src/state/README.md`
 - `layout-editor/src/state/interaction-telemetry.ts`
 - `layout-editor/docs/data-model-overview.md`
-- Fehlende Datei `layout-editor/docs/stage-instrumentation.md`
+- Stage-Instrumentations-Guide [`docs/stage-instrumentation.md`](../docs/stage-instrumentation.md)
 
 ## Lösungsideen
 - Stage-Instrumentations-Guide neu erstellen: Ereignis-Typen, Pflichtfelder, Reset-Konventionen und Logger-Verhalten beschreiben sowie Beispiel-Implementierungen für Observer/Logger aufnehmen.

--- a/todo/tooling-doc-audit.md
+++ b/todo/tooling-doc-audit.md
@@ -12,8 +12,7 @@ tags:
 # Tooling-Dokumentationsabgleich
 
 ## Originalkritik
-- `docs/README.md` listet nur `api-migrations.md` im Verzeichnis `docs/`, obwohl `persistence-diagnostics.md` und `stage-instrumentation.md` dort ebenfalls liegen.
-- Derselbe Index verlinkt auf `layout-editor/docs/persistence-diagnostics.md`, diese Datei existiert nicht; die Diagnose-Dokumentation befindet sich im Wurzel-`docs/`-Ordner.
+- `docs/README.md` muss alle Dateien im Wurzel-`docs/`-Verzeichnis (z. B. `persistence-diagnostics.md`, `stage-instrumentation.md`) abbilden und korrekt auf sie verlinken.
 - `layout-editor/tests/README.md` erwähnt den Ordner `helpers/` nicht, der als gemeinsames Test-Hilfsverzeichnis geführt wird, wodurch die Strukturübersicht lückenhaft bleibt.
 
 ## Kontext


### PR DESCRIPTION
## Summary
- list all user-facing docs in `docs/README.md` and fix the links to root-level articles
- document the shared `tests/helpers/` utilities and keep the test overview structured
- update telemetry references across src docs and to-dos to point at the stage instrumentation guide under `docs/`

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d790bf2e088325adb2d25ffc10f32c