### PR TITLE
Add documentation audit todos and cross-links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,3 +25,7 @@ Dieses Verzeichnis bündelt die nutzerorientierten Ergänzungen zum technischen 
 - Technische Detailentscheidungen findest du weiterhin direkt in den Deep-Dive-Dateien unter `layout-editor/docs/`.
 - Ergänzungen oder neue Artikel sollten hier verlinkt werden, damit Anwender:innen einen konsistenten Einstiegspunkt besitzen.
 - Offene technische Maßnahmen sind im [`../todo/`](../todo/) Verzeichnis dokumentiert und bei den jeweiligen Modulen verlinkt.
+
+## Offene Aufgaben
+
+- Integrations-Guides gegen Soll-Zustand prüfen: [`documentation-audit-integration-api.md`](../todo/documentation-audit-integration-api.md).

--- a/layout-editor/docs/README.md
+++ b/layout-editor/docs/README.md
@@ -19,7 +19,10 @@ related background material.
 
 ## To-Do
 
-- Store-Snapshots werden tief geklont. Details zur Nutzung der neuen Befehle (`moveElement`, `resizeElement`, `applyElementSnapshot`) stehen im [State-README](../src/state/README.md).
+- State-/History-Dokumentation auf Konsistenz prüfen: [`documentation-audit-state-model.md`](../todo/documentation-audit-state-model.md).
+- UI-Workflows und Interaktionen vollständig dokumentieren: [`documentation-audit-ui-experience.md`](../todo/documentation-audit-ui-experience.md).
+- Konfigurations- und Fehlerpfad-Dokumentation abgleichen: [`documentation-audit-configuration-settings.md`](../todo/documentation-audit-configuration-settings.md).
+- Integrations- und API-Guides aktualisieren: [`documentation-audit-integration-api.md`](../todo/documentation-audit-integration-api.md).
 
 For a high-level, user-facing overview of workflows and features, refer to the root
 [`docs/`](../../docs/) directory.

--- a/layout-editor/docs/data-model-overview.md
+++ b/layout-editor/docs/data-model-overview.md
@@ -80,3 +80,7 @@ fields stay in sync with the persisted layout schema:
 
 - [Documentation index](./README.md)
 - Related: [Layout history design](./history-design.md)
+
+## Offene Aufgaben
+
+- Lückenanalyse und Glossar-Abgleich: [`documentation-audit-state-model.md`](../todo/documentation-audit-state-model.md).

--- a/layout-editor/docs/domain-configuration.md
+++ b/layout-editor/docs/domain-configuration.md
@@ -115,3 +115,7 @@ hervorgehoben. Details zur Struktur der Bibliothek findest du in
   Änderungen an der JSON-Struktur sollten ausschließlich hier erweitert werden.
 - Tests (`tests/domain-configuration.test.ts`) decken Standardfall, erfolgreiche Vault-Ladung
   und Fehlerszenarien ab und dienen als Referenz für zukünftige Anpassungen.
+
+## Offene Aufgaben
+
+- Validierung & Soll-Dokumentation ergänzen: [`documentation-audit-configuration-settings.md`](../todo/documentation-audit-configuration-settings.md).

--- a/layout-editor/docs/history-design.md
+++ b/layout-editor/docs/history-design.md
@@ -31,3 +31,7 @@ The diff-first approach keeps history storage proportional to the number of modi
 
 - [Documentation index](./README.md)
 - Related: [Data model overview](./data-model-overview.md)
+
+## Offene Aufgaben
+
+- Konsistenzcheck und Ergänzungen siehe [`documentation-audit-state-model.md`](../todo/documentation-audit-state-model.md).

--- a/layout-editor/docs/layout-library.md
+++ b/layout-editor/docs/layout-library.md
@@ -55,3 +55,7 @@ Bei Erfolg werden Metadaten wie `createdAt`, `updatedAt` und `schemaVersion` ges
 - [Dokumentenindex](./README.md)
 - [`docs/persistence-errors.md`](./persistence-errors.md) – Detailbeschreibung des Persistenz-Banners und Fehlercodes.
 - [`docs/domain-configuration.md`](./domain-configuration.md) – Erläutert, wie Seed-Layouts in die Bibliothek synchronisiert werden.
+
+## Offene Aufgaben
+
+- Workflow-Dokumentation zwischen Bibliothek und UI prüfen: [`documentation-audit-ui-experience.md`](../todo/documentation-audit-ui-experience.md).

--- a/layout-editor/docs/persistence-errors.md
+++ b/layout-editor/docs/persistence-errors.md
@@ -30,3 +30,7 @@ werden.
 
 - [Dokumentenindex](./README.md)
 - Verwandt: [Layout-Bibliothek](./layout-library.md)
+
+## Offene Aufgaben
+
+- Fehlerpfad- und Wiki-Abgleich durchführen: [`documentation-audit-configuration-settings.md`](../todo/documentation-audit-configuration-settings.md).

--- a/layout-editor/docs/plugin-api.md
+++ b/layout-editor/docs/plugin-api.md
@@ -115,3 +115,7 @@ View-Bindings koppeln externe Render-Views an den Layout-Editor. Weitere Hinterg
 - [`docs/persistence-errors.md`](./persistence-errors.md) – Hintergrund zu Persistenz- und Migrationfehlern, die bei `saveLayout` oder `loadLayout` auftreten können.
 - [`docs/tooling.md`](./tooling.md) – Hinweise zu Tests und Bundling rund um die API.
 
+
+## Offene Aufgaben
+
+- Integrationsleitfäden und Versionierung prüfen: [`documentation-audit-integration-api.md`](../todo/documentation-audit-integration-api.md).

--- a/layout-editor/docs/tooling.md
+++ b/layout-editor/docs/tooling.md
@@ -25,4 +25,4 @@ Add new test files under `tests/` using the `*.test.ts` naming convention to hav
 
 ## Offene Aufgaben
 
-Derzeit keine. Ergänze hier einen Verweis, sobald im [`../../todo/`](../../todo/) Ordner neue Maßnahmen für das Tooling dokumentiert werden.
+- Integrationsdokumentation inkl. Tooling-Anforderungen prüfen: [`documentation-audit-integration-api.md`](../todo/documentation-audit-integration-api.md).

--- a/layout-editor/docs/ui-performance.md
+++ b/layout-editor/docs/ui-performance.md
@@ -55,3 +55,7 @@ Keeping these rules in mind ensures the rendering layer remains incremental, pre
 
 - [Documentation index](./README.md)
 - Related: [View Registry](./view-registry.md)
+
+## Offene Aufgaben
+
+- Interaktions- und Performance-Dokumentation konsolidieren: [`documentation-audit-ui-experience.md`](../todo/documentation-audit-ui-experience.md).

--- a/layout-editor/docs/view-registry.md
+++ b/layout-editor/docs/view-registry.md
@@ -45,3 +45,7 @@ Entwickler können diese Fehler auffangen, um alternative Workflows anzubieten (
 
 - [Dokumentenindex](./README.md)
 - Verwandt: [Plugin-API](./plugin-api.md)
+
+## Offene Aufgaben
+
+- Integrationspfade und Fehlerszenarien dokumentieren: [`documentation-audit-integration-api.md`](../todo/documentation-audit-integration-api.md).

--- a/layout-editor/src/config/README.md
+++ b/layout-editor/src/config/README.md
@@ -11,3 +11,7 @@ Configuration sources define how the editor loads domain-specific element metada
 - Always route configuration reads through the exported functions instead of accessing storage directly. They handle caching, validation, and default materialisation.
 - When introducing new configuration keys, update both the TypeScript interfaces and validation logic before extending the persisted schema. Document the new fields in the [domain configuration guide](../../docs/domain-configuration.md).
 - Domain source selection is controlled by the settings layer; new sources should integrate with [`../settings`](../settings/README.md) so users can toggle them at runtime.
+
+## Offene Punkte
+
+- Validierungs- und Fehlerdokumentation prüfen: [`documentation-audit-configuration-settings.md`](../../todo/documentation-audit-configuration-settings.md).

--- a/layout-editor/src/elements/README.md
+++ b/layout-editor/src/elements/README.md
@@ -35,3 +35,7 @@ Dieses Verzeichnis bündelt alle Layout-Editor-Komponenten, die als **Elements**
 - [Element Preview API](../element-preview.ts) – definiert, wie Previews im Editor gerendert werden.
 - [View Registry](../view-registry.ts) – stellt Feature-Bindings bereit, die z. B. vom `view-container` genutzt werden.
 - [UI-Komponenten](../ui/components) – Basisbausteine für Palette, Inspector und Modals.
+
+## Offene Punkte
+
+- Workflow- und Querverweis-Review: [`documentation-audit-ui-experience.md`](../../todo/documentation-audit-ui-experience.md).

--- a/layout-editor/src/model/README.md
+++ b/layout-editor/src/model/README.md
@@ -11,3 +11,7 @@ The model layer owns the canonical tree representation of layout elements. It pr
 - Extend `LayoutTree` with caution: keep internal nodes mutable for performance but return cloned objects (`cloneLayoutElement`) to callers to prevent accidental cross-frame mutation.
 - Use tree helpers from [`../utils`](../utils/README.md) to guard against cycles when introducing new traversal behaviour.
 - When adding new derived data (e.g. computed aggregations), expose dedicated accessors on the tree rather than mutating element payloads. Document the data contract in the [data model overview](../../docs/data-model-overview.md) if schema changes are introduced.
+
+## Offene Punkte
+
+- Konsistenz- und Vollständigkeitsprüfung siehe [`documentation-audit-state-model.md`](../../todo/documentation-audit-state-model.md).

--- a/layout-editor/src/presenters/README.md
+++ b/layout-editor/src/presenters/README.md
@@ -62,3 +62,7 @@ Der Header-Presenter bündelt Element-Picker, Canvas-Größeneingaben, Exportans
 - [UI Rendering Pipeline](../../docs/ui-performance.md) – Performance-Charakteristika der Stage, Tree- und Header-Komponenten.
 - [Stage-Instrumentierung & Telemetrie](../../../docs/stage-instrumentation.md) – Detailbeschreibung der Kamera- und Interaktions-Hooks.
 - [View Registry](../../docs/view-registry.md) – Integration der Presenter in den View-Lifecycle.
+
+## Offene Punkte
+
+- Dokumentationslücken und Workflow-Abgleich siehe [`documentation-audit-ui-experience.md`](../../todo/documentation-audit-ui-experience.md).

--- a/layout-editor/src/settings/README.md
+++ b/layout-editor/src/settings/README.md
@@ -14,3 +14,7 @@ Settings modules integrate the layout editor with Obsidian's preferences UI and 
 - Wenn Einstellungen Laufzeitdaten beeinflussen (z. B. Domänenquelle → Seed-Sync), registriere Change-Listener wie `onDomainConfigurationSourceChange` und delegiere an die zuständigen Services.
 - Document user-facing workflows for new settings in the [domain configuration documentation](../../docs/domain-configuration.md) or other relevant guides under `docs/`.
 - When adding new toggles, define the underlying state or configuration first (see [`../config`](../config/README.md)) and inject the render helper into `settings-tab.ts`.
+
+## Offene Punkte
+
+- Soll-Dokumentation der Einstellungen aktualisieren: [`documentation-audit-configuration-settings.md`](../../todo/documentation-audit-configuration-settings.md).

--- a/layout-editor/src/state/README.md
+++ b/layout-editor/src/state/README.md
@@ -16,3 +16,7 @@ The state layer coordinates mutable editor state, history, and event emission. I
 - Structural behaviour (parenting, child order, validation) is implemented in the [`model`](../model/README.md) layer. Prefer to add tree capabilities there and call them from the store.
 - For a data contract overview, refer to the [data model documentation](../../docs/data-model-overview.md). Keep store exports aligned with the documented schema so persistence and tests continue to pass.
 - Stage telemetry must be instrumented through `stageInteractionTelemetry`. Extend the `StageInteractionEvent` union and observer/logger interfaces together, keep payloads JSON-serialisable, update [`layout-editor-store.instrumentation.test.ts`](../../tests/layout-editor-store.instrumentation.test.ts), and document the new events in the [stage instrumentation guide](../../../docs/stage-instrumentation.md). Always reset hooks via `resetStageInteractionTelemetry()` in tests to avoid leaks.
+
+## Offene Punkte
+
+- Siehe [`documentation-audit-state-model.md`](../../todo/documentation-audit-state-model.md) für den Soll-Ist-Abgleich der State- und History-Dokumentation.

--- a/layout-editor/src/ui/README.md
+++ b/layout-editor/src/ui/README.md
@@ -23,3 +23,7 @@ Dieser Ordner enthält die UI-Hilfsfunktionen des Layout-Editors – insbesonder
 - Architektur-Überblick: [`../README.md`](../README.md)
 - Performance-Guidelines für UI-Widgets: [`../../docs/ui-performance.md`](../../docs/ui-performance.md)
 - Projektweite Einordnung & Workflows: [`../../../README.md`](../../../README.md)
+
+## Offene Punkte
+
+- Dokumentationsabgleich für Interaktionen und Presenter: [`documentation-audit-ui-experience.md`](../../todo/documentation-audit-ui-experience.md).

--- a/todo/README.md
+++ b/todo/README.md
@@ -5,12 +5,20 @@ Dieses Verzeichnis sammelt alle offenen To-Dos für den Layout-Editor. Jede Date
 ## Strukturdiagramm
 
 - `README.md` – Index des Backlogs, beschreibt Struktur, Konventionen und Metadaten-Standard.
+- `documentation-audit-state-model.md` – Audit der Dokumentation für State-, Datenmodell- und History-Flows.
+- `documentation-audit-ui-experience.md` – Review der UI-, Presenter- und Interaktionsdokumentation.
+- `documentation-audit-configuration-settings.md` – Überprüfung der Konfigurations- und Settings-Dokumentation.
+- `documentation-audit-integration-api.md` – Validierung der Integrations- und Plugin-API-Dokumente.
 - `store-snapshot-immutability-tests.md` – Regressionstest für unveränderliche Store-Snapshots.
 
 ## Backlog-Übersicht
 
 | Datei | Kategorie | Priorität | Kurzbeschreibung |
 | --- | --- | --- | --- |
+| [`documentation-audit-state-model.md`](documentation-audit-state-model.md) | Dokumentation | Hoch | Audit für State-, Datenmodell- und History-Dokumentation durchführen. |
+| [`documentation-audit-ui-experience.md`](documentation-audit-ui-experience.md) | Dokumentation | Mittel | UI-, Presenter- und Workflow-Dokumentation auf Lücken prüfen. |
+| [`documentation-audit-configuration-settings.md`](documentation-audit-configuration-settings.md) | Dokumentation | Mittel | Konfigurations-, Settings- und Fehlerpfad-Dokumentation abgleichen. |
+| [`documentation-audit-integration-api.md`](documentation-audit-integration-api.md) | Dokumentation | Mittel | Integrations- und Plugin-API-Guides auf Vollständigkeit prüfen. |
 | [`store-snapshot-immutability-tests.md`](store-snapshot-immutability-tests.md) | Tests | Mittel | Regressionstest sicherstellen, dass Store-Snapshots außerhalb des Stores nicht mutiert werden können. |
 
 Sobald neuer Handlungsbedarf entsteht, lege eine eigene Markdown-Datei in diesem Ordner an und verlinke sie in dieser Tabelle nach Priorität.

--- a/todo/documentation-audit-configuration-settings.md
+++ b/todo/documentation-audit-configuration-settings.md
@@ -1,0 +1,37 @@
+---
+status: open
+priority: medium
+area:
+  - documentation
+  - configuration
+owner: unassigned
+tags:
+  - domain-config
+  - settings
+links:
+  - layout-editor/src/config/README.md
+  - layout-editor/src/settings/README.md
+  - layout-editor/docs/domain-configuration.md
+  - layout-editor/docs/persistence-errors.md
+---
+
+# Konfigurations- und Einstellungen-Dokumentation prüfen
+
+## Originalkritik
+- Zwischen Config-, Settings- und Persistence-Dokumenten bestehen Lücken: Validierungsregeln werden teilweise nur im Code erwähnt, Fehlerpfade fehlen im Wiki, und die Verlinkung zum User-Wiki ist unvollständig.
+
+## Kontext
+- Domain-Konfigurationen und Benutzereinstellungen sind Grundlage für kundenspezifische Layouts. Ohne vollständige Dokumentation steigt die Gefahr von Fehlkonfigurationen und Supportaufwand.
+- Änderungen an Validierungslogik oder Fallback-Strategien müssen nachvollziehbar dokumentiert sein, damit Deployments planbar bleiben.
+
+## Betroffene Module
+- `layout-editor/src/config/README.md`
+- `layout-editor/src/settings/README.md`
+- `layout-editor/docs/domain-configuration.md`
+- `layout-editor/docs/persistence-errors.md`
+
+## Lösungsideen
+- Review aller Validierungs- und Fallback-Pfade, inkl. Mapping der Fehlermeldungen auf Persistence-/Config-Dokumentation.
+- Ergänzung eines Soll-Zustands im User-Wiki, der zentrale Setup-Flows beschreibt und auf modulare Detaildokumente verweist.
+- Prüfen, ob Environment-abhängige Optionen und Migrationspfade dokumentiert sind; fehlende Inhalte ergänzen oder als Folge-To-Do erfassen.
+- Tabelle der Konfigurationsschlüssel mit Standardwerten und Verantwortlichkeiten aktualisieren.

--- a/todo/documentation-audit-integration-api.md
+++ b/todo/documentation-audit-integration-api.md
@@ -1,0 +1,37 @@
+---
+status: open
+priority: medium
+area:
+  - documentation
+  - integration
+owner: unassigned
+tags:
+  - plugin-api
+  - view-registry
+links:
+  - layout-editor/docs/plugin-api.md
+  - layout-editor/docs/view-registry.md
+  - layout-editor/docs/tooling.md
+  - docs/README.md
+---
+
+# Integrations- und API-Dokumentation validieren
+
+## Originalkritik
+- Die Plugin-API- und View-Registry-Dokumente decken Versionierung und Fehlerbehandlung ab, verweisen jedoch nicht auf aktuelle Tooling-Standards oder das zentrale User-Wiki. Integratoren erhalten keine vollständige Schritt-für-Schritt-Anleitung.
+
+## Kontext
+- Externe Plugins sind auf stabile Integrationsverträge angewiesen. Inkonsistente Dokumentation führt zu Integrationsfehlern, erhöhtem Supportaufwand und unsicheren Release-Prozessen.
+- Tooling- und CI-Anforderungen müssen im gleichen Zug überprüft werden, um die Lieferfähigkeit zu sichern.
+
+## Betroffene Module
+- `layout-editor/docs/plugin-api.md`
+- `layout-editor/docs/view-registry.md`
+- `layout-editor/docs/tooling.md`
+- `docs/README.md`
+
+## Lösungsideen
+- Prüfen, ob alle öffentlich exponierten APIs dokumentiert und mit Versionshinweisen versehen sind; fehlende Einträge ergänzen.
+- Integrationsleitfäden im User-Wiki verankern und Rückverweise in den Modul-Dokumenten hinzufügen.
+- Tooling-Voraussetzungen (Build, Tests, Linting) gegen aktuelle Skripte abgleichen und Aktualisierungen dokumentieren.
+- Beispiel-Workflows (Setup, Registrierung, Fehlerdiagnose) als How-to erfassen oder auf bestehende Guides verlinken.

--- a/todo/documentation-audit-state-model.md
+++ b/todo/documentation-audit-state-model.md
@@ -1,0 +1,36 @@
+---
+status: open
+priority: high
+area:
+  - documentation
+  - state
+owner: unassigned
+tags:
+  - layout-editor-core
+  - data-model
+links:
+  - layout-editor/src/state/README.md
+  - layout-editor/src/model/README.md
+  - layout-editor/docs/data-model-overview.md
+---
+
+# State- und Datenmodell-Dokumentation verifizieren
+
+## Originalkritik
+- Die bestehenden Readmes zum State-Layer und zum Datenmodell verweisen aufeinander, enthalten jedoch unterschiedliche Details zu Snapshot-Verträgen, Serialisierung und Schema-Evolution. Es ist unklar, ob alle aktuell implementierten Flows (History, Export, Telemetrie) vollständig dokumentiert sind und konsistente Begrifflichkeiten verwenden.
+
+## Kontext
+- Der Layout-Editor lehnt sich stark an das zentrale Store- und Modellkonzept an. Fehlerhafte oder lückenhafte Dokumentation führt zu Missverständnissen bei Integratoren und gefährdet die Wartbarkeit der Kernfunktionen.
+- Insbesondere neuere Funktionen wie differenzbasierte Patches, elementare Constraint-Validierungen und Telemetrie-Hooks benötigen einen Soll-Zustand im Wiki, damit Tests und Architekturentscheidungen nachvollziehbar bleiben.
+
+## Betroffene Module
+- `layout-editor/src/state/README.md`
+- `layout-editor/src/model/README.md`
+- `layout-editor/docs/data-model-overview.md`
+- `layout-editor/docs/history-design.md`
+
+## Lösungsideen
+- Soll-Ist-Abgleich für alle State-APIs und Datenstrukturen erstellen und fehlende Abschnitte in den Readmes bzw. im User-Wiki ergänzen.
+- Begrifflichkeiten (z. B. *LayoutSnapshot*, *Patch*, *HistoryFrame*) vereinheitlichen und mit Glossar-Abschnitt verlinken.
+- Dokumentationslücken mit konkreten Aufgaben nachziehen (z. B. fehlende Sequenzdiagramme, unbeschriebene Edge-Cases) und anschließend Tests referenzieren.
+- Ergebnis im User-Wiki zusammenfassen und dort auf die detaillierten Modul-Dokumente verweisen.

--- a/todo/documentation-audit-ui-experience.md
+++ b/todo/documentation-audit-ui-experience.md
@@ -1,0 +1,38 @@
+---
+status: open
+priority: medium
+area:
+  - documentation
+  - ui
+owner: unassigned
+tags:
+  - presenters
+  - interaction-design
+links:
+  - layout-editor/src/ui/README.md
+  - layout-editor/src/elements/README.md
+  - layout-editor/src/presenters/README.md
+  - layout-editor/docs/ui-performance.md
+---
+
+# UI- und Interaktionsdokumentation konsolidieren
+
+## Originalkritik
+- Die UI-Readmes listen Komponenten und Presenter, dokumentieren aber nicht durchgängig die Interaktions-Workflows (Drag & Drop, Snapping, Tastenkürzel). Zwischen UI-Performance-Guidelines und Element-Dokumentation fehlen Querverweise.
+
+## Kontext
+- Neue Komponenten und Refactorings werden ohne klare Dokumentationsbasis risikoreich. Reviewer und Integratoren benötigen nachvollziehbare Abläufe und erwartete Nutzerinteraktionen.
+- Das User-Wiki beschreibt die Soll-Workflows, verweist jedoch nicht immer zurück auf technische Details der Module.
+
+## Betroffene Module
+- `layout-editor/src/ui/README.md`
+- `layout-editor/src/elements/README.md`
+- `layout-editor/src/presenters/README.md`
+- `layout-editor/docs/ui-performance.md`
+- `layout-editor/docs/layout-library.md`
+
+## Lösungsideen
+- Abläufe für zentrale Interaktionen als Sequenz- oder Aktivitätsdiagramm dokumentieren und in den Modul-Readmes verankern.
+- Tastenkürzel, Gesten und Barrierefreiheitsanforderungen im User-Wiki abgleichen und sicherstellen, dass technische Readmes auf die Soll-Prozesse verweisen.
+- Performance-Guidelines mit konkreten Beispielen aus den UI-Modulen ergänzen und gegenseitig verlinken.
+- Validieren, dass Tests die dokumentierten Workflows abdecken, und fehlende Szenarien als weitere To-Dos erfassen.


### PR DESCRIPTION
## Summary
- add four documentation audit tasks covering state/model, UI workflows, configuration/settings, and integration/API guides
- update the todo index and relevant module docs to link to the new audits for visibility

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68d7966cdddc8325b5ce4323b67fe2a0