### PR TITLE
Add todo for comprehensive UI components wiki

### DIFF
--- a/layout-editor/src/ui/components/README.md
+++ b/layout-editor/src/ui/components/README.md
@@ -25,6 +25,9 @@ Die Komponenten in diesem Ordner implementieren die interaktiven Widgets der Can
 - `context.scope.register(cleanup)` verknüpft beliebige Aufräumlogik (z. B. Observer, Timer, Kind-Komponenten). Der Cleanup wird beim Entfernen des Knotens oder beim `DiffRenderer.clear()`-Aufruf ausgeführt.
 - Kombiniere Scope-Hilfen mit komponentenweiten `registerCleanup`-Einträgen: globale Listener bleiben am Komponenten-Scope, Knoten-spezifische Ressourcen hängen am Diff-Kontext und werden durch den Renderer freigegeben.
 
+## Offene Aufgaben
+- [To-Do: UI-Komponenten-Wiki vervollständigen](../../../../todo/ui-components-wiki.md)
+
 ## Weiterführende Dokumentation
 - Canvas- und Rendering-Details: [`../../docs/ui-performance.md`](../../docs/ui-performance.md)
 - Architektur des `src`-Moduls: [`../../README.md`](../../README.md)

--- a/todo/README.md
+++ b/todo/README.md
@@ -16,6 +16,7 @@ Dieses Verzeichnis sammelt alle offenen To-Dos für den Layout-Editor. Jede Date
 | Datei | Kategorie | Priorität | Kurzbeschreibung |
 | --- | --- | --- | --- |
 | [`documentation-audit-state-model.md`](documentation-audit-state-model.md) | Dokumentation | Hoch | Audit für State-, Datenmodell- und History-Dokumentation durchführen. |
+| [`ui-components-wiki.md`](ui-components-wiki.md) | Dokumentation | Hoch | Vollständiges Wiki mit Einträgen für jede UI-Komponente planen. |
 | [`documentation-audit-ui-experience.md`](documentation-audit-ui-experience.md) | Dokumentation | Mittel | UI-, Presenter- und Workflow-Dokumentation auf Lücken prüfen. |
 | [`documentation-audit-configuration-settings.md`](documentation-audit-configuration-settings.md) | Dokumentation | Mittel | Konfigurations-, Settings- und Fehlerpfad-Dokumentation abgleichen. |
 | [`documentation-audit-integration-api.md`](documentation-audit-integration-api.md) | Dokumentation | Mittel | Integrations- und Plugin-API-Guides auf Vollständigkeit prüfen. |

--- a/todo/ui-components-wiki.md
+++ b/todo/ui-components-wiki.md
@@ -1,0 +1,39 @@
+---
+status: open
+priority: high
+area:
+  - documentation
+  - user-wiki
+owner: unassigned
+tags:
+  - ui-components
+  - wiki
+links:
+  - layout-editor/src/ui/components/README.md
+  - docs/README.md
+---
+
+# UI-Komponenten-Wiki vervollständigen
+
+## Originalkritik
+- Das User-Wiki beschreibt die Layout-Bearbeitung nur auf hoher Ebene; eine vollständige Referenz für die einzelnen UI-Komponenten fehlt.
+- Auf der Arbeitsfläche verfügbare Elemente (Stage, Strukturbaum, Inspector-Bausteine, Banner usw.) besitzen keine eigenen Wiki-Einträge.
+- Entwickler finden derzeit keine einheitliche Quelle, die Eigenschaften, Zustände und Interaktionsmuster pro Komponente festhält.
+
+## Kontext
+- Das User-Wiki dient als verbindliche Soll-Dokumentation für Workflows und Komponenten. Ohne dedizierte Einträge entsteht Wissensverlust bei Onboarding, QA und Erweiterungen.
+- Neue Komponenten oder Refactorings laufen Gefahr, inkonsistente Bedienmuster zu schaffen, wenn ihre Anforderungen nicht dokumentiert sind.
+- Reviewer benötigen nachvollziehbare Referenzen, um UI-Änderungen gegen definierte Erwartungen zu prüfen.
+
+## Betroffene Module
+- `layout-editor/src/ui/components/` (alle UI-Komponenten)
+- `layout-editor/src/ui/README.md`
+- `docs/README.md`
+- User-Wiki (Ordner TBD – muss identifiziert und mit Referenzen ergänzt werden)
+
+## Lösungsideen
+- Vollständige Liste aller im Editor verfügbaren UI-Komponenten zusammentragen (Canvas-Elemente, Inspector, Strukturbaum, Banner, Kontextmenüs usw.).
+- Pro Komponente einen Wiki-Eintrag planen: Zweck, Interaktionen, Zustände, Abhängigkeiten, Barrierefreiheitsnotizen und Links zu technischen Readmes.
+- Informationsarchitektur definieren (Navigationsstruktur, Querverweise zwischen Komponenten, Zuordnung zu Workflows im User-Wiki).
+- Abgleich mit technischen Dokumenten (`layout-editor/src/ui/components/README.md`, Tests, Performance-Guides), um konsistente Begriffe und Verantwortlichkeiten festzulegen.
+- Review-Checkliste entwerfen, damit künftige Komponenten denselben Dokumentationsstandard erfüllen.


### PR DESCRIPTION
## Summary
- add high-priority to-do to plan a complete UI components wiki with entries per component
- link the new to-do from the UI components documentation and backlog overview

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7980a89348325b125d8ddfc2525c8