### PR TITLE
Update layout editor state/model docs to match implementation

### DIFF
--- a/layout-editor/src/model/README.md
+++ b/layout-editor/src/model/README.md
@@ -1,16 +1,43 @@
 # Model
 
-The model layer owns the canonical tree representation of layout elements. It provides efficient lookups, parent/child validation, and snapshot generation that the store and presenters consume when reacting to user input.
+Das Modell bildet die kanonische Baumstruktur aller Layout-Elemente ab. Es konzentriert Validierung, Eltern-Kind-Beziehungen und Ordnungsverwaltung an einer Stelle.
 
-## Files
+## Struktur
 
-- `layout-tree.ts` – Maintains the element graph, ensuring unique identifiers, preserving insertion order, validating container relationships, and exposing immutable snapshots for the state layer.
+```
+model/
+├─ README.md
+└─ layout-tree.ts
+```
 
-## Conventions & Extension Points
+## LayoutTree
 
-- Extend `LayoutTree` with caution: keep internal nodes mutable for performance but return cloned objects (`cloneLayoutElement`) to callers to prevent accidental cross-frame mutation.
-- Use tree helpers from [`../utils`](../utils/README.md) to guard against cycles when introducing new traversal behaviour.
-- When adding new derived data (e.g. computed aggregations), expose dedicated accessors on the tree rather than mutating element payloads. Document the data contract in the [data model overview](../../docs/data-model-overview.md) if schema changes are introduced.
+`layout-tree.ts` implementiert den `LayoutTree`, der alle `LayoutElement`-Instanzen als mutierbare Nodes hält und die externe Welt ausschließlich über geklonte Snapshots versorgt.
+
+### Kernaufgaben
+
+- **Initialisierung (`load`)** – importiert persistierte Elemente, entfernt ungültige Elternreferenzen, synchronisiert `parentId`/`children` und stellt eindeutige IDs sicher.
+- **Lookups** – `getElement`, `getChildIds`, `getChildElements` und `getParentId` liefern referenzierte Nodes für Store-Operationen. Vor jeder Rückgabe werden `children`-Arrays aktualisiert.
+- **Mutation** – `insert`, `update`, `remove`, `setParent` und `moveChild` kapseln alle Schreibzugriffe. Der Baum verhindert Zyklen, Mehrfach-Einträge und sorgt für konsistente Reihenfolgen.
+- **Snapshot-Erzeugung** – `getElementsSnapshot()` liefert die globale Reihenfolge aus `order` und stellt Container-Kinder ebenfalls bereit. Der Store klont diese Elemente vor der weiteren Verteilung.
+
+### Wichtige Garantien
+
+- `children` ist eine abgeleitete Struktur: Container ohne Kinder liefern ein leeres Array, Nicht-Container setzen `children` auf `undefined`.
+- Elternwechsel über `setParent` validieren Zielcontainer (`isContainerType`), verhindern Selbstreferenzen und prüfen zyklische Beziehungen.
+- Beim Entfernen eines Elements werden Kinder automatisch entkoppelt und bleiben in der globalen Reihenfolge erhalten, bis der Store weitere Maßnahmen ergreift.
+- `moveChild` verschiebt Kinder innerhalb eines Containers, clamped auf gültige Indizes.
+
+## Konventionen & Erweiterungspunkte
+
+- Interne Node-Objekte bleiben mutierbar, dürfen aber nur über `LayoutTree`-APIs verändert werden. Konsumenten erhalten Kopien via `cloneLayoutElement` (siehe [State-Layer](../state/README.md)).
+- Neue Traversal-/Analysefunktionen sollten Hilfsfunktionen aus [`../utils`](../utils/README.md) nutzen, um z. B. Zyklen frühzeitig zu erkennen.
+- Schema-Erweiterungen (zusätzliche Felder auf `LayoutElement`) erfordern Anpassungen an `load`, `cloneLayoutElement` und der Dokumentation im [Data Model Overview](../../docs/data-model-overview.md).
+
+## Navigation
+
+- [Data Model Overview](../../docs/data-model-overview.md)
+- [State Layer](../state/README.md)
 
 ## Offene Punkte
 

--- a/layout-editor/src/state/README.md
+++ b/layout-editor/src/state/README.md
@@ -1,22 +1,60 @@
 # State
 
-The state layer coordinates mutable editor state, history, and event emission. It exposes the `LayoutEditorStore` as the single entry point for canvas interactions, selection, and persistence, producing deep-cloned snapshots for the view layer while delegating structural integrity to the model.
+Das State-Layer kapselt sämtliche Editor-Zustände, orchestriert History-Replays und bündelt Telemetrie-Hooks für die Canvas.
 
-## Files
+## Struktur
 
-- `layout-editor-store.ts` – Central store that orchestrates element CRUD, canvas sizing, selection, drag state, export payload caching, and undo/redo integration via `LayoutHistory`.
-- `interaction-telemetry.ts` – Consolidated observer/logger hub for stage interactions; exposes setters for runtime probes and the event union defined in the [stage instrumentation guide](../../../docs/stage-instrumentation.md).
+```
+state/
+├─ README.md
+├─ interaction-telemetry.ts
+└─ layout-editor-store.ts
+```
 
-## Conventions & Extension Points
+## LayoutEditorStore
 
-- All UI and presenter code should mutate editor state exclusively through `LayoutEditorStore` methods. Direct mutations of element arrays will be overwritten on the next snapshot because the store always re-synchronises from the model tree. Use dedicated commands such as `moveElement`, `resizeElement`, `offsetChildren`, and `applyElementSnapshot` to describe changes instead of mutating `LayoutElement` instances in-place.
-- `getState()` and emitted `state` events return detached clones. Mutating snapshots has no side effects; to persist inline edits, feed the mutated draft back through `applyElementSnapshot` or another command.
-- New state transitions must record history through `commitHistory()` so undo/redo stays consistent; consult the [history design notes](../../docs/history-design.md) for patch guidelines.
-- When expanding the public state shape, update the exported `LayoutEditorState` type and adjust serialization/restore logic. Use immutable snapshots for outward-facing state to keep observers deterministic.
-- Structural behaviour (parenting, child order, validation) is implemented in the [`model`](../model/README.md) layer. Prefer to add tree capabilities there and call them from the store.
-- For a data contract overview, refer to the [data model documentation](../../docs/data-model-overview.md). Keep store exports aligned with the documented schema so persistence and tests continue to pass.
-- Stage telemetry must be instrumented through `stageInteractionTelemetry`. Extend the `StageInteractionEvent` union and observer/logger interfaces together, keep payloads JSON-serialisable, update [`layout-editor-store.instrumentation.test.ts`](../../tests/layout-editor-store.instrumentation.test.ts), and document the new events in the [stage instrumentation guide](../../../docs/stage-instrumentation.md). Always reset hooks via `resetStageInteractionTelemetry()` in tests to avoid leaks.
+`layout-editor-store.ts` stellt den `LayoutEditorStore` als zentrale Fassade bereit. Er verwaltet Canvas-Geometrie (`canvasWidth`, `canvasHeight`), Auswahl- und Drag-State, laufende Speicher-/Import-Vorgänge sowie die Metadaten des zuletzt gespeicherten Layouts. Öffentliche Snapshots (`LayoutEditorState`) liefern ausschließlich tief geklonte Elementdaten.
+
+### Snapshot-Lifecycle
+
+- `subscribe` liefert initiale `state`- und `export`-Events und hält Listener mit geklonten Snapshots synchron.
+- `getState()` und jedes `state`-Event basieren auf `createSnapshot()`, das `cloneLayoutElement` für alle Baumknoten nutzt. Mutationen an Snapshots sind damit folgenlos.
+- Änderungen an Elementen laufen immer über den `LayoutTree`; nach jeder Mutation sorgt `markStateMutated()` dafür, dass `serializeState()` bei Bedarf einen neuen Export-Payload erzeugt.
+- `emitState()` bündelt Ereignisse während `runInteraction()`-Blöcken. Sobald die Interaktionstiefe wieder 0 ist, wird – abhängig vom `skipExport`-Flag – ein `state`-/`export`-Paar dispatcht.
+- `flushExport()` zwingt eine sofortige `export`-Emission und sollte nach `skipExport`-Operationen genutzt werden, wenn externe Konsumenten frische JSON-Payloads benötigen.
+
+### History-Integration
+
+- Der Store hält eine `LayoutHistory`-Instanz (siehe [`history-design`](../../docs/history-design.md)). Über `commitHistory()` bzw. `pushHistorySnapshot()` werden differenzbasierte Patches registriert.
+- `captureSnapshot()` liefert die Grundlage für History-Patches und Undo/Redo; `restoreSnapshot()` lädt Elemente erneut in den `LayoutTree` und triggert anschließend einen State-Emit.
+- Während History-Replays meldet `LayoutHistory.isRestoring` laufende Wiederherstellungen. `commitHistory()` prüft diese Flagge und verhindert dadurch Re-Entrancy-Bugs.
+- Undo/Redo aktualisiert nach dem Replay erneut die abgeleiteten Flags (`canUndo`, `canRedo`) und stößt Export-Revalidierungen an.
+
+### Telemetrie
+
+- `runInteraction()` kapselt jede Benutzeraktion, erhöht/dekrementiert die Interaktionstiefe und feuert `interaction:start`/`interaction:end` über `stageInteractionTelemetry`.
+- `setCanvasSize()` erzeugt `canvas:size`-Events inklusive voriger, angefragter und resultierender Maße.
+- `clampElementsToCanvas()` meldet jedes Clamping als `clamp:step` (Element-ID, vorheriger Frame, Ergebnis und Canvas-Dimensionen).
+- Die Event-Typen und Observer-Schnittstellen sind in [`interaction-telemetry.ts`](./interaction-telemetry.ts) definiert; Detailbeschreibung und Testanforderungen stehen im [Stage-Instrumentation Guide](../../../docs/stage-instrumentation.md).
+
+## interaction-telemetry.ts
+
+Der Telemetrie-Hub stellt Observer- und Logger-Schnittstellen (`StageInteractionObserver`, `StageInteractionLogger`) bereit, normalisiert Events (`StageInteractionEvent`) und bietet Helper zum Setzen/Zurücksetzen aktiver Hooks. Logger erhalten jedes Event zusätzlich zu konkreten Observer-Callbacks.
+
+## Konventionen & Erweiterungspunkte
+
+- UI-/Presenter-Code darf Editor-Elemente ausschließlich über Store-APIs mutieren (`moveElement`, `resizeElement`, `offsetChildren`, `applyElementSnapshot`, …). Direkte Array-Manipulationen im Snapshot gehen beim nächsten Tree-Sync verloren.
+- Bei neuen State-Feldern `LayoutEditorState` sowie Export-/Restore-Flows synchron aktualisieren. Outbound-Snapshots bleiben unveränderlich.
+- Neue History-Transitionen müssen `commitHistory()` durchlaufen, damit Undo/Redo konsistent bleibt. Für Patch-Richtlinien siehe [History-Design](../../docs/history-design.md).
+- Telemetrie-Erweiterungen erfordern: neue Payload-Typen in `StageInteractionEvent`, angepasste Tests (`layout-editor-store.instrumentation.test.ts`) und Dokumentations-Updates im Stage-Instrumentation Guide. Tests müssen `resetStageInteractionTelemetry()` verwenden, um Hook-Leaks zu vermeiden.
+- Baumstruktur, Eltern-/Kind-Validierung und weitere Invarianten gehören in das [`model`](../model/README.md); der Store konsumiert diese Fähigkeiten.
+
+## Navigation
+
+- [Data Model Overview](../../docs/data-model-overview.md)
+- [History Design](../../docs/history-design.md)
+- [Stage-Instrumentation Guide](../../../docs/stage-instrumentation.md)
 
 ## Offene Punkte
 
-- Siehe [`documentation-audit-state-model.md`](../../todo/documentation-audit-state-model.md) für den Soll-Ist-Abgleich der State- und History-Dokumentation.
+- Konsolidierte Soll/Ist-Prüfung siehe [`documentation-audit-state-model.md`](../../todo/documentation-audit-state-model.md).


### PR DESCRIPTION
## Summary
- refresh the state layer README with the current snapshot, history and telemetry lifecycles
- document LayoutTree responsibilities and schema guarantees in the model README
- update the data-model and history design docs to reflect cloning, persistence metadata and bounded patches

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d79961acec832585452e5843a245f0