### PR TITLE
Document domain configuration validation and persistence mappings

### DIFF
--- a/layout-editor/docs/domain-configuration.md
+++ b/layout-editor/docs/domain-configuration.md
@@ -17,6 +17,8 @@ Validierungsregeln der Konfiguration sowie die notwendigen Schritte zur Aktivier
 
 Die Auswahl wird über `localStorage` pro Client gesichert, sodass der zuletzt verwendete Modus beim nächsten Start wiederhergestellt wird.
 
+> **Hinweis:** Plattform- oder Speicher-Besonderheiten (z. B. mobile Vaults ohne `localStorage`) sind noch nicht dokumentiert. Siehe To-do [`domain-configuration-environment-docs.md`](../todo/domain-configuration-environment-docs.md).
+
 ## Weiterführend
 
 - [Dokumentenindex](./README.md)
@@ -84,19 +86,31 @@ gefüllt (Default-Attributgruppen, Standard-Element-Definitionen und Seed-Layout
 Die Laufzeitvalidierung überprüft sämtliche Pflichtfelder der Domänenkonfiguration:
 
 - **Attributgruppen** benötigen einen String `label` sowie ein nicht-leeres Array von
-  Optionen (`value` und `label` als Strings).
+  Optionen (`value` und `label` als Strings). Optionen mit Non-String-Werten werden verworfen und protokolliert.【F:layout-editor/src/config/domain-source.ts†L628-L707】
 - **Element-Definitionen** müssen `type`, `buttonLabel`, `defaultLabel`, `width` und `height`
   als Pflichtfelder enthalten. Zahlenwerte müssen positiv sein. Optionale Felder wie
   `options`, `defaultLayout`, `defaultValue` usw. werden übernommen, sofern die Datentypen
-  stimmen.
+  stimmen.【F:layout-editor/src/config/domain-source.ts†L707-L815】
 - **Seed-Layouts** verlangen `id`, `name` sowie ein Blueprint mit `canvasWidth`,
   `canvasHeight` und mindestens einem gültigen Element. Elementdaten prüfen Koordinaten,
-  Größe, `label` und optionale Strukturen wie `layout`, `children` oder `options`.
+  Größe, `label` und optionale Strukturen wie `layout`, `children` oder `options`.【F:layout-editor/src/config/domain-source.ts†L815-L908】
 
 Tritt ein Validierungsfehler auf, wird die Konfiguration verworfen, der Ladevorgang schlägt mit
 `DomainConfigurationError` fehl und die Defaults bleiben aktiv. Die Fehlermeldung enthält alle
 betroffenen Pfade (z. B. `elementDefinitions[0].buttonLabel`), damit Korrekturen schnell
-möglich sind.
+möglich sind.【F:layout-editor/src/config/domain-source.ts†L921-L1074】
+
+## Validierungs- & Fallback-Matrix
+
+| Komponente | Validierungslogik | Fallback | Fehleroberfläche |
+| --- | --- | --- | --- |
+| Attributgruppen | `validateAttributeGroups` prüft Struktur und Wertetypen, entfernt invalide Optionen und sammelt Fehler per `ValidationCollector`.【F:layout-editor/src/config/domain-source.ts†L628-L707】 | Fehlende bzw. invalide Gruppen werden durch Defaults ersetzt, sobald die Konfiguration angewendet wird.【F:layout-editor/src/config/domain-source.ts†L1000-L1023】 | `DomainConfigurationError` mit Pfadangaben; Fehler erscheinen im Log und können im Persistenz-Banner angezeigt werden (siehe [Persistenzfehler](./persistence-errors.md#fehlertypen--codes)). |
+| Element-Definitionen | `validateElementDefinitions` erzwingt Pflichtfelder, validiert Layout/Children-Objekte und verwirft unvollständige Elemente.【F:layout-editor/src/config/domain-source.ts†L707-L815】 | Auf Defaults zurückfallen, falls Liste leer oder invalide Daten enthält.【F:layout-editor/src/config/domain-source.ts†L1000-L1023】 | Fehlerdetails in `DomainConfigurationError.details`; UI kann sie im Debug-Panel oder Support-Logs anzeigen. |
+| Seed-Layouts | `validateSeedLayouts` kontrolliert IDs, Namen, Canvasgrößen und Elemente; ohne valide Elemente wird das Layout verworfen.【F:layout-editor/src/config/domain-source.ts†L815-L908】 | Default-Seeds werden verwendet, wenn keine gültigen Seeds geladen werden konnten.【F:layout-editor/src/config/domain-source.ts†L1008-L1023】 | Seed-Sync löst Notices und Banner aus, sobald ungültige Seeds verworfen werden (siehe [Seed-Layouts synchronisieren](#seed-layouts-synchronisieren)). |
+| Vault-Adapter | `readVaultConfiguration` prüft `exists`/`read`-Methoden und fängt JSON-Parsing-Fehler ab.【F:layout-editor/src/config/domain-source.ts†L1025-L1074】 | Bei fehlender Datei oder Fehlern kehrt der Service vollständig zu den Defaults zurück.【F:layout-editor/src/config/domain-source.ts†L994-L1035】 | Fehler werden im Seed-Sync geloggt; geplantes Banner-Mapping siehe [`domain-configuration-environment-docs.md`](../todo/domain-configuration-environment-docs.md). |
+
+- Die Settings-Schicht (`src/settings/domain-settings.ts`) garantiert, dass nur bekannte Quellen (`builtin`, `vault`) aktiviert werden können; Details siehe [Settings README](../src/settings/README.md#validierungs--fallback--fehlerübersicht).
+- Erweiterungen müssen die Matrix erweitern und neue Fehlercodes mit dem Persistenzbanner abstimmen.
 
 ## Seed-Layouts synchronisieren
 
@@ -107,7 +121,7 @@ die eingebauten Seeds zurückgegriffen. Jeder Wechsel der Domänenquelle löst d
 Synchronisationslauf erneut aus. Die Routine ist idempotent: Bereits vorhandene Layout-Dateien
 bleiben unangetastet, fehlende Seeds werden ergänzt und erkannte Konflikte werden im Log
 hervorgehoben. Details zur Struktur der Bibliothek findest du in
-[`layout-library.md`](./layout-library.md).
+[`layout-library.md`](./layout-library.md) sowie in der Fehler-Matrix unter [Persistenzfehler](./persistence-errors.md#fehlertypen--codes).
 
 ## Entwicklungsnotizen
 
@@ -119,3 +133,4 @@ hervorgehoben. Details zur Struktur der Bibliothek findest du in
 ## Offene Aufgaben
 
 - Validierung & Soll-Dokumentation ergänzen: [`documentation-audit-configuration-settings.md`](../todo/documentation-audit-configuration-settings.md).
+- Plattform-/Storage-Sonderfälle dokumentieren: [`domain-configuration-environment-docs.md`](../todo/domain-configuration-environment-docs.md).

--- a/layout-editor/docs/persistence-errors.md
+++ b/layout-editor/docs/persistence-errors.md
@@ -14,6 +14,21 @@ zu Vault-Pfaden, Schema-Regeln und Fehlerquellen liefert [`layout-library.md`](.
   - Originalfehlermeldung, falls sie nicht bereits durch die Empfehlung abgedeckt ist.
 - **Benachrichtigung:** Parallel erscheint weiterhin ein Obsidian-Notice mit einer zusammengefassten Meldung.
 - **Rücksetzung:** Bei erfolgreichem Speichern oder erneuten Interaktionen verschwindet der Banner automatisch.
+- **Konsistenz:** Die Codes spiegeln direkt die Validierungen aus der [Domain-Konfigurations-Matrix](./domain-configuration.md#validierungs--fallback-matrix) und der [`layout-library`](./layout-library.md) wider.
+
+## Fehlertypen & Codes
+
+| Code | Quelle der Validierung | Bannerinhalt & Empfehlungen | Fallback-Verhalten |
+| --- | --- | --- | --- |
+| `layout/id-invalid` | `resolveLayoutId` prüft IDs auf leere Werte.【F:layout-editor/src/layout-library.ts†L176-L210】 | Titel „Ungültige Layout-ID“, Hinweis auf gültige Namen, Empfehlung zur Umbenennung.【F:layout-editor/src/presenters/header-controls.ts†L24-L83】 | Speichern wird abgebrochen; bestehende Layout-Dateien bleiben unverändert.【F:layout-editor/src/layout-library.ts†L193-L233】 |
+| `layout/id-invalid-characters` | Blockiert Pfadtrenner in IDs.【F:layout-editor/src/layout-library.ts†L176-L191】 | Banner beschreibt unzulässige Zeichen, verweist auf Entfernen von `/` und `\`.【F:layout-editor/src/presenters/header-controls.ts†L24-L83】 | Kein Dateischreibversuch; Nutzer korrigiert Namen und speichert erneut.【F:layout-editor/src/layout-library.ts†L193-L233】 |
+| `layout/canvas-width-invalid` / `layout/canvas-height-invalid` | Validieren positive Canvas-Dimensionen vor dem Speichern.【F:layout-editor/src/layout-library.ts†L205-L233】 | Banner nennt gültigen Bereich (200–2000 px) und markiert das betroffene Maß.【F:layout-editor/src/presenters/header-controls.ts†L24-L83】 | Speichern schlägt fehl, UI behält letzte gültige Maße im Zustand.【F:layout-editor/src/state/layout-editor-store.ts†L1-L200】 |
+| `layout/elements-empty` | `saveLayoutToLibrary` fordert mindestens ein Element.【F:layout-editor/src/layout-library.ts†L270-L326】 | Banner fordert zum Hinzufügen von Elementen auf.【F:layout-editor/src/presenters/header-controls.ts†L24-L83】 | Keine Dateiänderung; Seed-Sync bleibt unverändert aktiv.【F:layout-editor/src/seed-layouts.ts†L1-L160】 |
+| `layout/elements-invalid` | Einzelne Elemente werden geprüft; invalide Werte lösen Fehler aus.【F:layout-editor/src/layout-library.ts†L270-L326】 | Banner erklärt, dass ein Element ungültige Eigenschaften enthält, und verweist auf die betroffene Gruppe.【F:layout-editor/src/presenters/header-controls.ts†L24-L83】 | Layout wird nicht gespeichert; Benutzer korrigiert Elemente oder lädt Seeds erneut.【F:layout-editor/src/layout-library.ts†L193-L326】 |
+| `layout/unknown` | Fallback für unbehandelte Fehler (z. B. Vault-Zugriffe).【F:layout-editor/src/presenters/header-controls.ts†L24-L83】 | Banner zeigt generische Meldung und listet Rohfehlermeldung, falls vorhanden.【F:layout-editor/src/presenters/header-controls.ts†L24-L83】 | Fehler wird geloggt; Anwender wiederholt Aktion oder prüft Vault-Protokolle.【F:layout-editor/src/presenters/header-controls.ts†L24-L83】 |
+
+- Domain-Konfigurationsfehler (`DomainConfigurationError`) werden derzeit nur im Seed-Sync geloggt. Das Mapping auf Banner-Codes (`config/...`) ist als Folgearbeit im To-do [`domain-configuration-environment-docs.md`](../todo/domain-configuration-environment-docs.md) dokumentiert.
+- Die Tabellenzeilen ergänzen die Validierungs-Matrix aus [`docs/domain-configuration.md`](./domain-configuration.md#validierungs--fallback-matrix) und dienen als Referenz für Reviewer.
 
 ## Beispiele
 
@@ -30,7 +45,9 @@ werden.
 
 - [Dokumentenindex](./README.md)
 - Verwandt: [Layout-Bibliothek](./layout-library.md)
+- Validierungen & Fallbacks: [Domain-Konfigurationsdokumentation](./domain-configuration.md#validierungs--fallback-matrix)
 
 ## Offene Aufgaben
 
 - Fehlerpfad- und Wiki-Abgleich durchführen: [`documentation-audit-configuration-settings.md`](../todo/documentation-audit-configuration-settings.md).
+- Fehlercode-Mapping für Domain-Konfiguration erweitern (z. B. `config/...`-Codes): [`domain-configuration-environment-docs.md`](../todo/domain-configuration-environment-docs.md).

--- a/layout-editor/src/config/README.md
+++ b/layout-editor/src/config/README.md
@@ -2,7 +2,13 @@
 
 Configuration sources define how the editor loads domain-specific element metadata, attribute groups, and seed layouts. The logic here resolves the active configuration, validates incoming payloads, and exposes defaults for callers that need deterministic fallback data.
 
-## Files
+## Struktur & Dateien
+
+```text
+config/
+├── README.md (dieses Dokument)
+└── domain-source.ts – Lädt Domänendaten, validiert Payloads und stellt Fallbacks bereit
+```
 
 - `domain-source.ts` – Loads the configured domain bundle (builtin or vault JSON), validates payloads, exposes helper types for seed layouts, and emits descriptive errors when configuration is invalid.
 
@@ -12,6 +18,19 @@ Configuration sources define how the editor loads domain-specific element metada
 - When introducing new configuration keys, update both the TypeScript interfaces and validation logic before extending the persisted schema. Document the new fields in the [domain configuration guide](../../docs/domain-configuration.md).
 - Domain source selection is controlled by the settings layer; new sources should integrate with [`../settings`](../settings/README.md) so users can toggle them at runtime.
 
+## Validierungen, Fallbacks & Fehlerpfade
+
+| Bereich | Validierungen | Fallback-Strategie | Fehleroberfläche & Referenzen |
+| --- | --- | --- | --- |
+| Attributgruppen (`attributeGroups`) | Prüft, dass jedes Objekt ein String-Label enthält und alle Optionen Strings sind.【F:layout-editor/src/config/domain-source.ts†L628-L707】 | Fehlende oder invalide Gruppen werden durch die Defaults ersetzt.【F:layout-editor/src/config/domain-source.ts†L1000-L1023】 | `DomainConfigurationError` mit Pfadangaben; Details dokumentiert unter [Validierungs-Matrix](../../docs/domain-configuration.md#validierungs--fallback-matrix). |
+| Element-Definitionen (`elementDefinitions`) | Validiert Pflichtfelder (`type`, `buttonLabel`, `defaultLabel`, Dimensionen) und optionale Arrays/Layouts.【F:layout-editor/src/config/domain-source.ts†L707-L815】 | Bei Fehlern oder leerer Liste greifen die Standarddefinitionen.【F:layout-editor/src/config/domain-source.ts†L1000-L1023】 | Fehlerdetails werden an Listener propagiert und im Log ausgegeben; siehe [Persistenzfehler](../../docs/persistence-errors.md#fehlertypen--codes). |
+| Seed-Layouts (`seedLayouts`) | Erzwingt IDs, Namen, Canvasmaße und mindestens ein valides Element pro Layout.【F:layout-editor/src/config/domain-source.ts†L815-L908】 | Ungültige Seeds führen zum Rückfall auf Default-Seeds; vorhandene gültige Seeds werden übernommen.【F:layout-editor/src/config/domain-source.ts†L1008-L1023】 | Seed-Sync meldet Fehler als `DomainConfigurationError`; Seed-Synchronisation dokumentiert in [Domain Configuration](../../docs/domain-configuration.md#seed-layouts-synchronisieren). |
+| Vault-Zugriff | Überprüft Adapter-Methoden `exists`/`read` und fängt JSON-Parsing-Fehler ab.【F:layout-editor/src/config/domain-source.ts†L1025-L1074】 | Bei fehlender Datei oder Fehlern wird vollständig auf die Defaults zurückgesetzt.【F:layout-editor/src/config/domain-source.ts†L994-L1035】 | Fehler werden im Seed-Sync geloggt; dedizierte Banner-Codes folgen laut To-do [`domain-configuration-environment-docs.md`](../../todo/domain-configuration-environment-docs.md). |
+
+- Die Tabelle spiegelt die Laufzeitlogik wider; Erweiterungen müssen hier und in der [Domain-Konfigurationsdokumentation](../../docs/domain-configuration.md) ergänzt werden.
+- Fehlerdetails werden als Liste (`details`) innerhalb von `DomainConfigurationError` ausgegeben. UI-Schichten können sie für Debug-Ausgaben oder Support-Hinweise verwenden.
+
 ## Offene Punkte
 
 - Validierungs- und Fehlerdokumentation prüfen: [`documentation-audit-configuration-settings.md`](../../todo/documentation-audit-configuration-settings.md).
+- Umgebungsspezifische Optionen (z. B. Mobile Vaults, Remote-Speicher) dokumentieren: [`domain-configuration-environment-docs.md`](../../todo/domain-configuration-environment-docs.md).

--- a/layout-editor/src/settings/README.md
+++ b/layout-editor/src/settings/README.md
@@ -2,7 +2,14 @@
 
 Settings modules integrate the layout editor with Obsidian's preferences UI and expose runtime toggles that affect configuration sources and editor behaviour.
 
-## Files
+## Struktur & Dateien
+
+```text
+settings/
+├── README.md (dieses Dokument)
+├── domain-settings.ts – Quelle & Listener für Domänenkonfiguration
+└── settings-tab.ts – Registriert den Obsidian-Settings-Tab und rendert Controls
+```
 
 - `domain-settings.ts` – Manages the active domain configuration source, persists the selection in `localStorage`, notifies listeners about changes, and renders the toggle control used in the settings tab.
 - `settings-tab.ts` – Registers the plugin settings tab, wires Obsidian's `PluginSettingTab` lifecycle to our renderers, and disposes registered handlers when the tab hides.
@@ -15,6 +22,18 @@ Settings modules integrate the layout editor with Obsidian's preferences UI and 
 - Document user-facing workflows for new settings in the [domain configuration documentation](../../docs/domain-configuration.md) or other relevant guides under `docs/`.
 - When adding new toggles, define the underlying state or configuration first (see [`../config`](../config/README.md)) and inject the render helper into `settings-tab.ts`.
 
+## Validierungs-, Fallback- & Fehlerübersicht
+
+| Mechanismus | Validierung | Fallback | Fehlerdarstellung & Referenzen |
+| --- | --- | --- | --- |
+| `loadFromStorage` | Ignoriert unbekannte oder invalide Werte und protokolliert Warnungen statt Exceptions.【F:layout-editor/src/settings/domain-settings.ts†L9-L29】 | Rückfall auf `"builtin"`, wenn kein valider Wert gelesen werden kann.【F:layout-editor/src/settings/domain-settings.ts†L7-L15】 | Konsole warnt; Dokumentation siehe [Domain-Konfiguration](../../docs/domain-configuration.md#validierungs--fallback-matrix). |
+| `persistSource` | Fängt `localStorage`-Fehler ab (z. B. Safari Private Mode) und protokolliert sie.【F:layout-editor/src/settings/domain-settings.ts†L21-L32】 | Active Source bleibt unverändert, UI behält letzten bekannten Wert.【F:layout-editor/src/settings/domain-settings.ts†L32-L38】 | Warnungen erscheinen nur in der Konsole; Anwender folgen dem Fehlerbanner bei Persistenzproblemen (siehe [Persistenzfehler](../../docs/persistence-errors.md#fehlertypen--codes)). |
+| Toggle-Rendering | Synchronisiert UI-Wert mit Runtime-Quelle und verhindert Drift bei externen Änderungen.【F:layout-editor/src/settings/domain-settings.ts†L40-L86】 | Falls Listener fehlschlägt, bleibt Toggle beim letzten Wert; Domain-Service fällt auf Defaults zurück (siehe [`../config`](../config/README.md#validierungen-fallbacks--fehlerpfade)). | UI synchronisiert Banner & Notices über die Persistenz-Schicht, sobald Domain-Service Fehler meldet. |
+
+- Änderungen an Settings müssen die verlinkte Validierungs-Matrix in [`docs/domain-configuration.md`](../../docs/domain-configuration.md#validierungs--fallback-matrix) aktualisieren.
+- Bei neuen Quellen sind Speicherfehler (z. B. mobile Geräte ohne `localStorage`) in [`docs/persistence-errors.md`](../../docs/persistence-errors.md) zu ergänzen.
+
 ## Offene Punkte
 
 - Soll-Dokumentation der Einstellungen aktualisieren: [`documentation-audit-configuration-settings.md`](../../todo/documentation-audit-configuration-settings.md).
+- Umgebungsspezifische Optionen (Offline-/Mobile-Storage) dokumentieren: [`domain-configuration-environment-docs.md`](../../todo/domain-configuration-environment-docs.md).

--- a/todo/domain-configuration-environment-docs.md
+++ b/todo/domain-configuration-environment-docs.md
@@ -1,0 +1,42 @@
+---
+status: open
+priority: medium
+area:
+  - documentation
+  - configuration
+owner: unassigned
+tags:
+  - domain-config
+  - persistence
+  - environment
+links:
+  - layout-editor/src/config/README.md
+  - layout-editor/src/settings/README.md
+  - layout-editor/docs/domain-configuration.md
+  - layout-editor/docs/persistence-errors.md
+  - layout-editor/src/settings/domain-settings.ts
+  - layout-editor/src/config/domain-source.ts
+---
+
+# Environment-spezifische Optionen & Fehlerpfade dokumentieren
+
+## Kontext
+- Mobile Clients und Sandboxed Browser bieten keinen vollwertigen `localStorage` bzw. Vault-Zugriff; das Verhalten bei aktivierter Vault-Konfiguration ist derzeit nur im Code ersichtlich.
+- `DomainConfigurationError` wird zwar geloggt, aber ohne dedizierte Fehlercodes (`config/...`) in die Persistenzanzeige eingespeist.
+- Remote-Speicher (z. B. iCloud/Obsidian Sync) können Lese-/Schreibverzögerungen verursachen, die nicht in der Dokumentation adressiert sind.
+
+## Betroffene Module
+- `src/config/domain-source.ts` (Vault-Lesezugriff, Default-Fallbacks)
+- `src/settings/domain-settings.ts` (Persistenz der Quellenwahl, lokale Fallbacks)
+- `docs/domain-configuration.md`, `src/config/README.md`, `src/settings/README.md`, `docs/persistence-errors.md`
+
+## Offene Fragen
+- Wie dokumentieren wir den empfohlenen Workflow für Geräte ohne `localStorage`? (z. B. automatischer Rückfall auf `builtin`, sichtbare Hinweise im UI)
+- Welche Fehlercodes sollen für `DomainConfigurationError` eingeführt werden, damit Persistenzbanner konfigurationsbezogene Probleme klar benennen?
+- Müssen zusätzliche Retry-/Backoff-Strategien für verzögerte Vault-Zugriffe beschrieben werden?
+
+## Lösungsideen
+- Erweiterung der Persistenz-Dokumentation um eine Sektion „Plattformbesonderheiten“ mit konkreten Handlungsschritten pro Plattform.
+- Einführung einer Fehlercode-Tabelle `config/...` analog zur bestehenden `layout/...`-Matrix; Mapping in `describeLayoutPersistenceError` ergänzen.
+- Ergänzende Tests oder Monitoring-Hooks beschreiben, die Remote-Latenzen sichtbar machen (z. B. Diagnostics-Events im Seed-Sync).
+- Abgleich mit dem User-Wiki: Verlinken, wie Anwender Domain-Konfigurationen auf mobilen Geräten aktivieren bzw. Fehler erkennen.


### PR DESCRIPTION
## Summary
- add structure overviews and validation matrices to the configuration and settings README files
- extend the domain configuration guide with linked validation and fallback tables and reference persistence error handling
- document banner error codes, cross-link related guides, and capture remaining environment-specific gaps in a dedicated to-do

## Testing
- npm install *(fails: registry access returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d79a461208832594c0d50db4d82508