### PR TITLE
docs: expand setup and diagnostics guidance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,25 @@ Dieses Verzeichnis bündelt die nutzerorientierten Ergänzungen zum technischen 
 - [`persistence-diagnostics.md`](persistence-diagnostics.md) – Monitoring-Checks und Leitplanken für Speicherintegrität im Clusterbetrieb.
 - [`stage-instrumentation.md`](stage-instrumentation.md) – Messpunkte, KPIs und Alarmierungs-Setup für Deploy- und Preview-Stages.
 
+## Setup-Workflows
+
+- **Plugin-Aktivierung:** Folge dem How-To im User-Wiki-Einstieg und kontrolliere anschließend in der [Plugin-API-Referenz](../layout-editor/docs/plugin-api.md#setup-workflow-f%C3%BCr-integratoren), wie externe Module die API beziehen.
+- **Entwicklungsumgebung:** Richte Node.js-Abhängigkeiten im Verzeichnis `layout-editor/` ein und spiegle CI-Checks über die [Tooling-Dokumentation](../layout-editor/docs/tooling.md#setup-workflow).
+- **View-Bindings:** Verwende die Schritt-für-Schritt-Anleitung in der [View-Registry-Dokumentation](../layout-editor/docs/view-registry.md#setup-workflow), um neue Visualisierungen einzubinden.
+- **Offene Lücke:** Die verbindliche Node.js-/Obsidian-Version für lokale Setups fehlt noch – dokumentiert im To-Do [`onboarding-runtime-compatibility.md`](../todo/onboarding-runtime-compatibility.md).
+
+## Versionierung & Release-Hinweise
+
+- Konsultiere [`api-migrations.md`](api-migrations.md) für verbindliche SemVer-Prozesse und Release-Checklisten.
+- Die [Plugin-API](../layout-editor/docs/plugin-api.md#versionierung--kompatibilit%C3%A4t) beschreibt Guard-Methoden für Integratoren.
+- Tooling-Updates, die CI betreffen, sind in [`layout-editor/docs/tooling.md`](../layout-editor/docs/tooling.md#versionierung--ci-kontext) dokumentiert.
+
+## Fehlerdiagnose & Qualitätschecks
+
+- Schnellstart für Fehlersuche in der Layout-Persistenz liefert [`persistence-diagnostics.md`](persistence-diagnostics.md); technische Details befinden sich in [`layout-editor/docs/persistence-errors.md`](../layout-editor/docs/persistence-errors.md).
+- Für View-Probleme Verweise auf [`layout-editor/docs/view-registry.md#diagnose--fehlerbehebung`](../layout-editor/docs/view-registry.md#diagnose--fehlerbehebung) verwenden.
+- Stage- und CI-Anforderungen sind in [`stage-instrumentation.md`](stage-instrumentation.md) sowie im [Tooling-Guide](../layout-editor/docs/tooling.md#tooling--ci-anforderungen) gebündelt.
+
 ## Verwandte Deep-Dives in `layout-editor/docs/`
 
 - [`plugin-api.md`](../layout-editor/docs/plugin-api.md) – Vollständige Referenz der öffentlichen Plugin-API inklusive Fehlerszenarien.
@@ -29,3 +48,4 @@ Dieses Verzeichnis bündelt die nutzerorientierten Ergänzungen zum technischen 
 ## Offene Aufgaben
 
 - Integrations-Guides gegen Soll-Zustand prüfen: [`documentation-audit-integration-api.md`](../todo/documentation-audit-integration-api.md).
+- Runtime-Voraussetzungen für Entwickler dokumentieren: [`onboarding-runtime-compatibility.md`](../todo/onboarding-runtime-compatibility.md).

--- a/layout-editor/docs/plugin-api.md
+++ b/layout-editor/docs/plugin-api.md
@@ -7,7 +7,16 @@ Methoden. Die Signaturen basieren auf `src/main.ts`.
 ## Navigation
 
 - [Dokumentenindex](./README.md)
+- User-Wiki: [`docs/README.md`](../../docs/README.md#verwandte-deep-dives-in-layout-editordocs)
 - Verwandt: [View-Registry](./view-registry.md)
+
+## Setup-Workflow für Integratoren
+
+1. **Plugin laden:** `const plugin = app.plugins.getPlugin("layout-editor");` prüfen und per User-Wiki-Anleitung aktivieren, falls `undefined`.
+2. **API beziehen:** `const api = plugin?.getApi();` ruft die hier dokumentierten Methoden ab. Bei `undefined` sicherstellen, dass das Layout-Editor-Plugin fertig initialisiert ist (`await plugin.loadPromise`).
+3. **Version absichern:** Vor Feature-Aufrufen `api.assertApiVersion("1.0.0", "<feature>");` oder `api.withMinimumApiVersion` nutzen.
+4. **Tooling vorbereiten:** Vor Commits `npm install` im Ordner `layout-editor/` ausführen und die in [Tooling](./tooling.md) dokumentierten Checks laufen lassen, damit CI-Äquivalenz erreicht wird.
+5. **Workflows nachvollziehen:** Für Nutzerflüsse auf das User-Wiki unter [`docs/`](../../docs/README.md) verweisen und technische Tiefenlinks aus diesem Dokument verwenden.
 
 ## Versionierung & Kompatibilität
 
@@ -20,6 +29,12 @@ Methoden. Die Signaturen basieren auf `src/main.ts`.
 
 > **Hinweis:** Versionen werden tolerant geparst (Nicht-Ziffern werden entfernt). Verwende trotzdem reguläre SemVer-Strings wie
 > `"1.0.0"` oder `"1.2.3"`, um unerwartete Normalisierungen zu vermeiden.
+
+**Strategische Leitplanken:**
+
+- Folge dem SemVer-Prozess aus [`docs/api-migrations.md`](../../docs/api-migrations.md) bei Breaking Changes und dokumentiere neue Minimalversionen direkt in Pull Requests.
+- Verwende `isApiVersionAtLeast` oder `assertApiVersion` als Guard – reine Stringvergleiche auf `apiVersion` sind fehleranfällig bei zweistelligen Minor-/Patch-Versionen.
+- Teste neue Registry-Features in Feature-Branches und halte die CI-Kette (`npm run lint`, `npm run format`, `npm test`) grün; Abweichungen samt Migrationshinweisen im User-Wiki dokumentieren.
 
 ## View-Integration
 
@@ -77,6 +92,14 @@ Die Layout-Bibliothek verwaltet Layout-Dateien im Vault.
 
 > **Migrationen:** Die Rückgabewerte enthalten `schemaVersion`. Falls `loadLayout` `null` liefert, sollte das aufrufende Plugin eine Nutzerwarnung ausgeben (z. B. „Layout-Version nicht unterstützt“).
 
+## Diagnose & Fehlerbehebung
+
+- **Persistenz- und Schemafehler:** Ergänzende Matrix in [`docs/persistence-errors.md`](./persistence-errors.md) sowie Benutzerwarnungen im User-Wiki unter [`persistence-diagnostics`](../../docs/persistence-diagnostics.md).
+- **Registry-Konflikte:** Protokolliere `api.getViewBindingIds()` bzw. `api.getElementDefinitions()`; sie liefern Snapshots für Debugging.
+- **Tool-gestützte Analyse:** Nutze `npm run lint`, `npm test` und `npm run format` (siehe [Tooling](./tooling.md)) im Fehlerfall frühzeitig, um Regressionsursachen einzugrenzen.
+- **Stage-/CI-Checks:** Deploy- und Preview-Stage-Anforderungen sind in [`docs/stage-instrumentation.md`](../../docs/stage-instrumentation.md) dokumentiert.
+- **Noch offene Onboarding-Lücke:** Die verifizierten Node.js- und Obsidian-Versionen für Integrationen sind nicht festgehalten – siehe [`onboarding-runtime-compatibility.md`](../todo/onboarding-runtime-compatibility.md).
+
 ## View-Bindings registrieren
 
 View-Bindings koppeln externe Render-Views an den Layout-Editor. Weitere Hintergründe enthält [`docs/view-registry.md`](./view-registry.md).
@@ -109,13 +132,18 @@ View-Bindings koppeln externe Render-Views an den Layout-Editor. Weitere Hinterg
 - **Defaults wiederherstellen:** `resetElementDefinitions()` ohne Argument lädt die Standarddefinitionen; `resetViewBindings()` ohne Argument leert die Registry.
 - **Aufräumen:** Plugins sollten Listener und registrierte Definitionen/Bindings beim eigenen `onunload` entfernen, um Seiteneffekte bei Reloads zu vermeiden.
 
-## Weiterführende Ressourcen
+## Tooling & CI-Anforderungen
 
-- [`docs/view-registry.md`](./view-registry.md) – Detaillierte Informationen zur View-Registry inklusive Fehlermeldungen.
-- [`docs/persistence-errors.md`](./persistence-errors.md) – Hintergrund zu Persistenz- und Migrationfehlern, die bei `saveLayout` oder `loadLayout` auftreten können.
-- [`docs/tooling.md`](./tooling.md) – Hinweise zu Tests und Bundling rund um die API.
+- **Qualitätssicherung:** `npm run lint`, `npm run format`, `npm test` müssen vor Merge-Anträgen erfolgreich sein; sie spiegeln die CI-Pipeline.
+- **Build-Prüfung:** `npm run build` erzeugt die Bundle-Artefakte, die auch in Release-Pipelines genutzt werden.
+- **Manifest-Validierung:** `node scripts/generate-component-manifest.mjs` wird automatisch über `npm run build` ausgeführt und sollte lokal überprüft werden, wenn neue Elemente oder Views registriert werden.
+- **Weitere Ressourcen:**
+  - [`docs/view-registry.md`](./view-registry.md) – Detaillierte Informationen zur View-Registry inklusive Fehlermeldungen.
+  - [`docs/persistence-errors.md`](./persistence-errors.md) – Hintergrund zu Persistenz- und Migrationfehlern.
+  - [`docs/tooling.md`](./tooling.md) – Übersicht aller unterstützten Befehle samt Setup-Schritten.
 
 
 ## Offene Aufgaben
 
 - Integrationsleitfäden und Versionierung prüfen: [`documentation-audit-integration-api.md`](../todo/documentation-audit-integration-api.md).
+- Runtime-Voraussetzungen für Integratoren klären: [`onboarding-runtime-compatibility.md`](../todo/onboarding-runtime-compatibility.md).

--- a/layout-editor/docs/tooling.md
+++ b/layout-editor/docs/tooling.md
@@ -2,6 +2,14 @@
 
 This project relies on shared linting, formatting, and test tooling to keep contributions consistent and verifiable. The commands below run locally and in CI.
 
+## Setup-Workflow
+
+1. **Abhängigkeiten installieren:** `npm install` im Verzeichnis `layout-editor/` ausführen. Das erzeugt `node_modules/` und synchronisiert `package-lock.json`.
+2. **Node-Version prüfen:** Verwende die in der Entwicklungsumgebung definierte LTS-Version (fehlende Projektangabe – siehe [`onboarding-runtime-compatibility.md`](../todo/onboarding-runtime-compatibility.md)).
+3. **Erstlauf:** `npm run lint && npm test` einmalig starten, um sicherzustellen, dass ESLint-Cache und Test-Runner korrekt initialisiert sind.
+4. **CI-Spiegelung:** Vor Pull Requests immer `npm run lint`, `npm run format`, `npm test` und `npm run build` ausführen; sie entsprechen den GitHub-Actions.
+5. **Artefakte räumen:** Bei widersprüchlichen Ergebnissen `rm -rf dist/` und `npm run build` aufrufen, um den bundelten Zustand zu aktualisieren.
+
 ## Linting
 
 - `npm run lint` – Runs ESLint with the TypeScript ruleset against the source, scripts, and test directories. The command fails on any lint error or warning.
@@ -18,9 +26,23 @@ This project relies on shared linting, formatting, and test tooling to keep cont
 
 Add new test files under `tests/` using the `*.test.ts` naming convention to have them discovered automatically.
 
+## Versionierung & CI-Kontext
+
+- Tooling-Updates folgen semantischer Versionierung in [`docs/api-migrations.md`](../../docs/api-migrations.md); Breaking Changes müssen dort referenziert werden.
+- ESLint-, Prettier- und TypeScript-Versionen werden über `package.json` gepflegt. Prüfe bei Upgrades die Release-Notes und dokumentiere Auswirkungen im User-Wiki.
+- CI nutzt dieselben Skripte; stelle sicher, dass neue Befehle (`npm run <...>`) in `package.json` definiert und hier dokumentiert werden.
+
+## Fehlerdiagnose
+
+- **Linting schlägt fehl:** Mit `npm run lint -- --debug` ausführlichere Logs aktivieren und problematische Dateien anhand der Regel-ID korrigieren.
+- **Format-Checks:** `npm run format -- --loglevel debug` zeigt überschrittene Dateiliste an. Nutze `npm run format:fix` und kontrolliere die Änderungen über Git-Diff.
+- **Tests brechen ab:** `node scripts/run-tests.mjs --watch` zur Reproduktion mit Hot-Reload nutzen. Persistente Fehler gegen [`docs/persistence-errors.md`](./persistence-errors.md) oder das User-Wiki (`../../docs/persistence-diagnostics.md`) gegenprüfen.
+- **Build-Probleme:** `npm run build -- --log-level=debug` zeigt Esbuild-Details. Prüfe zusätzlich `scripts/generate-component-manifest.mjs` bei Schemaänderungen.
+
 ## Navigation
 
 - [Documentation index](./README.md)
+- User-Wiki: [`docs/README.md`](../../docs/README.md#verwandte-deep-dives-in-layout-editordocs)
 - Related: [Plugin API](./plugin-api.md)
 
 ## Offene Aufgaben

--- a/layout-editor/docs/view-registry.md
+++ b/layout-editor/docs/view-registry.md
@@ -2,6 +2,26 @@
 
 Die View-Registry kapselt alle Bindings, über die externe Plugins eigene Visualisierungen im Layout-Editor verfügbar machen. Sie stellt eine kleine API zur Verfügung, mit der Module ihre Views registrieren, abfragen und auf Änderungen reagieren können. Eine Gesamtsicht auf alle öffentlich angebotenen Methoden inklusive Workflows bietet die [Plugin-API-Referenz](./plugin-api.md).
 
+## Navigation
+
+- [Dokumentenindex](./README.md)
+- User-Wiki: [`docs/README.md`](../../docs/README.md#verwandte-deep-dives-in-layout-editordocs)
+- Verwandt: [Plugin-API](./plugin-api.md)
+
+## Setup-Workflow
+
+1. **Plugin initialisieren:** Sicherstellen, dass das Layout-Editor-Plugin aktiv ist (`app.plugins.enablePlugin("layout-editor")` laut User-Wiki).
+2. **API-Version validieren:** `api.assertApiVersion("1.0.0", "view registry");` aufrufen, bevor Bindings registriert werden.
+3. **Binding entwerfen:** IDs, Labels und optionale Tags vorab festlegen. Doppelte IDs vermeiden – bei Bedarf `api.hasViewBinding(id)` prüfen.
+4. **Registrierung in Lifecycle-Hooks:** Registrierung innerhalb von `onload` durchführen und im `onunload` sauber entfernen (`unregisterViewBinding`), um Reload-Leaks zu vermeiden.
+5. **Tooling ausführen:** Vor Pull Requests `npm install` im Projektstamm `layout-editor/` und anschließend die Befehle aus [Tooling](./tooling.md) laufen lassen, damit CI-konforme Artefakte entstehen.
+
+## Versionierung & Kompatibilität
+
+- Alle Registry-Funktionen wurden mit API-Version `1.0.0` eingeführt. Neue Flags oder optionale Eigenschaften müssen mit `withMinimumApiVersion` abgesichert werden.
+- Änderungen an bestehenden Bindings sollten mit Versionshinweisen in [`docs/api-migrations.md`](../../docs/api-migrations.md) ergänzt werden.
+- Für externe Plugins empfiehlt sich ein Fail-Fast-Check über `assertApiVersion`, um Nutzer frühzeitig auf inkompatible Layout-Editor-Versionen hinzuweisen.
+
 ## Registrierung
 
 ```ts
@@ -41,6 +61,20 @@ Die Hilfsfunktionen erleichtern Fehlersuche und Telemetrie, ohne den bestehenden
 
 Entwickler können diese Fehler auffangen, um alternative Workflows anzubieten (z. B. UI-Benachrichtigungen oder automatische Umbenennungen).
 
+## Diagnose & Fehlerbehebung
+
+- **Registrierungsfehler:** Konsumiere die konkreten Fehlermeldungen (siehe oben) und ergänze Nutzerfeedback anhand der Richtlinien in [`docs/persistence-errors.md`](./persistence-errors.md).
+- **Debug-Snapshots:** `getViewBindingIds()` oder `getViewBindings()` in der Developer-Konsole protokollieren, um kollidierende IDs, falsche Tags oder Labels sichtbar zu machen.
+- **Stage-Monitoring:** Für Deploy-/Preview-Überwachung [`docs/stage-instrumentation.md`](../../docs/stage-instrumentation.md) konsultieren.
+- **Benutzerseitige Hinweise:** Das User-Wiki dokumentiert beobachtete Fehlermeldungen in [`persistence-diagnostics`](../../docs/persistence-diagnostics.md).
+- **Noch offen:** Die verifizierten Node.js- und Obsidian-Versionen für Registry-Erweiterungen sind unklar – siehe [`onboarding-runtime-compatibility.md`](../todo/onboarding-runtime-compatibility.md).
+
+## Tooling & CI-Anforderungen
+
+- `npm run lint`, `npm run format` und `npm test` sind Pflichtläufe vor Pull Requests; sie entsprechen dem CI-Gate.
+- `npm run build` validiert den Esbuild-Bundling-Prozess sowie die generierten Manifeste.
+- Für wiederkehrende Checks auf Branches können dieselben Befehle über die Stage-Pipelines laut [`docs/tooling.md`](./tooling.md) automatisiert werden.
+
 ## Weiterführend
 
 - [Dokumentenindex](./README.md)
@@ -49,3 +83,4 @@ Entwickler können diese Fehler auffangen, um alternative Workflows anzubieten (
 ## Offene Aufgaben
 
 - Integrationspfade und Fehlerszenarien dokumentieren: [`documentation-audit-integration-api.md`](../todo/documentation-audit-integration-api.md).
+- Runtime-Voraussetzungen für Registry-Erweiterungen klären: [`onboarding-runtime-compatibility.md`](../todo/onboarding-runtime-compatibility.md).

--- a/todo/onboarding-runtime-compatibility.md
+++ b/todo/onboarding-runtime-compatibility.md
@@ -1,0 +1,24 @@
+# Onboarding – Runtime Compatibility
+
+## Kontext
+- In den aktualisierten Setup-Leitfäden (User-Wiki, `layout-editor/docs/plugin-api.md`, `layout-editor/docs/tooling.md`, `layout-editor/docs/view-registry.md`) wird auf CI-gleiche Checks und Aktivierungsworkflows verwiesen.
+- Es fehlt jedoch eine verbindliche Aussage zu den unterstützten Node.js-Versionen sowie zur minimalen Obsidian-Version, die Integratoren lokal benötigen.
+- Ohne diese Angaben können neue Teammitglieder oder externe Plugin-Autoren in inkompatible Umgebungen installieren und Fehlverhalten schwerer einordnen.
+
+## Betroffene Module / Dokumente
+- `docs/README.md` (Setup-Workflows & Qualitätschecks)
+- `layout-editor/docs/plugin-api.md`
+- `layout-editor/docs/view-registry.md`
+- `layout-editor/docs/tooling.md`
+- potenziell `layout-editor/manifest.json` und Build-Skripte (`package.json`, `scripts/`)
+
+## Lösungsideen
+- Node.js LTS-Version aus CI-Definition oder `.nvmrc` ableiten und explizit in den Setup-Abschnitten dokumentieren.
+- Minimal unterstützte Obsidian-Version aus `manifest.json` validieren und prominent verlinken.
+- Optional: Automatisierten Preflight-Check (`npm run doctor`) einführen, der Node-Version und Obsidian-API-Level prüft.
+- User-Wiki um einen Abschnitt „Systemvoraussetzungen“ erweitern und aus technischen Deep-Dives darauf verlinken.
+
+## Erwartete Ergebnisse
+- Neue Entwickler:innen können ohne Trial-and-Error ein konsistentes Runtime-Setup herstellen.
+- CI- und lokale Ergebnisse nähern sich an, weil identische Node-Versionen verwendet werden.
+- Support-Anfragen zu „funktioniert nicht“ Szenarien lassen sich schneller abgleichen.


### PR DESCRIPTION
## Summary
- add setup workflows, versioning guardrails, and diagnostics pointers to the plugin API, view registry, and tooling guides
- synchronise the docs index with the user wiki navigation and cross-reference CI/tooling expectations
- capture the remaining runtime compatibility gap as a linked onboarding to-do

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d79c12c61c8325b67570fd105edfaa