### PR TITLE
Add UI documentation sequences and cross-links

### DIFF
--- a/layout-editor/docs/layout-library.md
+++ b/layout-editor/docs/layout-library.md
@@ -33,10 +33,22 @@ Beim Speichern aggregiert das Modul alle Validierungen, bevor die Datei geschrie
 
 Bei Erfolg werden Metadaten wie `createdAt`, `updatedAt` und `schemaVersion` gesetzt, sodass Folgeaufrufe konsistente Daten lesen können.【F:layout-editor/src/layout-library.ts†L204-L217】
 
+### Sequenz: Layout speichern
+1. Header-Presenter ruft `saveLayoutToLibrary` mit dem aktuellen Snapshot auf.【F:layout-editor/src/presenters/header-controls.ts†L312-L361】
+2. `resolveLayoutId` und Dimensionsprüfungen validieren Eingaben; Fehler werden früh geworfen.【F:layout-editor/src/layout-library.ts†L176-L233】
+3. Persistente Felder werden gesetzt und `app.vault.create/modify` geschrieben.【F:layout-editor/src/layout-library.ts†L204-L223】
+4. Erfolg/Fehler spiegelt der Header als Banner & Notice; Nutzerführung siehe [User-Wiki › Fehlerdiagnose](../../docs/README.md#fehlerdiagnose--qualit%C3%A4tschecks).
+
 ## Laden und Lesen
 
 - **Metadaten lesen:** `readLayoutMeta` analysiert jede JSON-Datei, verwirft invalide Dimensionen und Elemente und führt anschließend die Schema-Migrationen aus. Fehler beim Lesen werden protokolliert, das Layout wird dann übersprungen.【F:layout-editor/src/layout-library.ts†L340-L374】
 - **Listen & Einzelabruf:** `listSavedLayouts` und `loadSavedLayout` stellen sicher, dass der Zielordner existiert, bevor Dateien eingelesen werden.【F:layout-editor/src/layout-library.ts†L377-L395】
+
+### Sequenz: Layout laden
+1. UI fordert `listSavedLayouts` oder `loadSavedLayout` beim Presenter an.【F:layout-editor/src/presenters/header-controls.ts†L364-L409】
+2. Die Bibliothek validiert/vervollständigt Pfade, liest JSON-Dateien und führt Migrationen aus.【F:layout-editor/src/layout-library.ts†L28-L158】【F:layout-editor/src/layout-library.ts†L340-L374】
+3. Ungültige Layouts werden verworfen, Notice „Layout konnte nicht geladen werden“ bleibt optional im Header.【F:layout-editor/src/presenters/header-controls.ts†L364-L381】
+4. Aus Nutzersicht beschreibt der User-Wiki-Eintrag [Setup-Workflows › View-Bindings](../../docs/README.md#setup-workflows) die erwartete Wiederherstellung.
 
 ## Fehlerbilder und UI-Reaktionen
 
@@ -59,3 +71,4 @@ Bei Erfolg werden Metadaten wie `createdAt`, `updatedAt` und `schemaVersion` ges
 ## Offene Aufgaben
 
 - Workflow-Dokumentation zwischen Bibliothek und UI prüfen: [`documentation-audit-ui-experience.md`](../todo/documentation-audit-ui-experience.md).
+- Sequenzdiagramme & Accessibility-Kriterien nachziehen: [`ui-accessibility-and-diagrams.md`](../todo/ui-accessibility-and-diagrams.md).

--- a/layout-editor/src/elements/README.md
+++ b/layout-editor/src/elements/README.md
@@ -4,6 +4,17 @@ Dieses Verzeichnis bündelt alle Layout-Editor-Komponenten, die als **Elements**
 
 ## Struktur & Zuständigkeiten
 
+```
+elements/
+├── README.md             – Leitfaden (diese Datei)
+├── base.ts               – Basisklassen & Kontrakte
+├── component-manifest.ts – Generiertes Manifest (nicht manuell editieren)
+├── registry.ts           – Lookup für Elementdefinitionen
+├── ui.ts                 – UI-Primitiven für Palette & Inspector
+├── components/           – Konkrete Elementimplementierungen
+└── shared/               – Basishilfen für Komponenten & Renderer
+```
+
 | Pfad | Beschreibung |
 | --- | --- |
 | [`base.ts`](./base.ts) | Deklariert `LayoutElementComponent`, Preview-/Inspector-Kontexte sowie Factory-Signaturen, die von allen Element-Implementierungen genutzt werden. |
@@ -18,6 +29,26 @@ Dieses Verzeichnis bündelt alle Layout-Editor-Komponenten, die als **Elements**
 1. **Komponente ableiten:** Neue Elemente bauen auf den Basisklassen aus [`shared/component-bases.ts`](./shared/component-bases.ts) auf oder implementieren `LayoutElementComponent` direkt.
 2. **Registrieren:** Die Implementierung wird im Build-Prozess dem [`component-manifest.ts`](./component-manifest.ts) hinzugefügt und dadurch automatisch von [`registry.ts`](./registry.ts) erfasst.
 3. **UI anbinden:** Preview- und Inspector-Logik verwenden die Hilfsfunktionen aus [`ui.ts`](./ui.ts) sowie die globalen Presenter in [`../presenters`](../presenters), insbesondere [`stage-controller.ts`](../presenters/stage-controller.ts) für die Stage-Interaktion.
+
+## Kernabläufe
+
+### Palette → Stage (Drag & Drop)
+1. `createElementsField` liefert Palette-Einträge inklusive Drag-Metadaten.
+2. Beim Drop ruft der Presenter `store.addElementFromDefinition()`, wobei `registry.ts` Definition und Defaultwerte liefert.
+3. Die Stage empfängt den aktualisierten Snapshot und ruft `ensureContainerDefaults()` für neue Container.
+4. Der Nutzer-Workflow ist im User-Wiki unter [Stage-Bedienkonzept › Drag-Szenario](../../../docs/stage-instrumentation.md#tests--qualit%C3%A4tssicherung) beschrieben.
+
+### Inspector-Änderungen
+1. Inspector-Controls verwenden `createElementsSelect`/`createElementsField` aus [`ui.ts`](./ui.ts).
+2. Änderungen triggern Presenter-Callbacks (`StructurePanelPresenter` oder Header-Formulare), die `LayoutEditorStore.updateElement()` aufrufen.
+3. Der Store publiziert den Snapshot; Previews nutzen `syncElementNode` um nur betroffene Attribute zu patchen.
+4. Der Soll-Zustand für diese Bearbeitungsschritte ist im User-Wiki unter [Setup-Workflows › View-Bindings](../../../docs/README.md#setup-workflows) dokumentiert.
+
+### Manifest-Erweiterung
+1. Neue Komponenten werden in `components/` abgelegt.
+2. `npm run build` führt das Manifest-Script aus und registriert die Komponente in `component-manifest.ts`.
+3. `registry.ts` stellt die Definition bereit; Palette, Stage und Inspector erhalten sie beim nächsten Import.
+4. Offene Diagramme für diesen Ablauf sind im To-Do [`ui-accessibility-and-diagrams.md`](../../todo/ui-accessibility-and-diagrams.md) hinterlegt.
 
 ## Registry- & Manifest-Pipeline
 
@@ -35,7 +66,9 @@ Dieses Verzeichnis bündelt alle Layout-Editor-Komponenten, die als **Elements**
 - [Element Preview API](../element-preview.ts) – definiert, wie Previews im Editor gerendert werden.
 - [View Registry](../view-registry.ts) – stellt Feature-Bindings bereit, die z. B. vom `view-container` genutzt werden.
 - [UI-Komponenten](../ui/components) – Basisbausteine für Palette, Inspector und Modals.
+- Nutzerperspektive & Soll-Zustand: [`../../../docs/README.md`](../../../docs/README.md)
 
 ## Offene Punkte
 
 - Workflow- und Querverweis-Review: [`documentation-audit-ui-experience.md`](../../todo/documentation-audit-ui-experience.md).
+- Sequenzdiagramme & Barrierefreiheit: [`ui-accessibility-and-diagrams.md`](../../todo/ui-accessibility-and-diagrams.md).

--- a/layout-editor/src/ui/README.md
+++ b/layout-editor/src/ui/README.md
@@ -2,6 +2,18 @@
 
 Dieser Ordner enthält die UI-Hilfsfunktionen des Layout-Editors – insbesondere Menü- und Baumrendering – und stellt die Verbindung zwischen dem Store (`src/state`) und den wiederverwendbaren UI-Komponenten her.
 
+## Struktur & Inhalte
+
+```
+ui/
+├── README.md          – Leitfaden (diese Datei)
+├── components/        – komplexe UI-Komponenten (Stage, DiffRenderer, Shell …)
+├── editor-menu.ts     – Kontextmenüs für Canvas- und Tree-Aktionen
+├── element-tree.ts    – Baumdarstellung der Elementbibliothek
+├── utils/             – Low-Level-Helper (Formatierungen, Fokus-Utilities)
+└── utils.ts           – Einstiegspunkt für modulübergreifende Helfer
+```
+
 ## Inhalte
 - [`components/`](components/README.md) – Sammlung der komplexen UI-Komponenten (Stage, DiffRenderer, Shell usw.).
 - [`editor-menu.ts`](editor-menu.ts) – Erzeugt kontextuelle Aktionsmenüs für Canvas- und Bauminteraktionen.
@@ -19,11 +31,39 @@ Dieser Ordner enthält die UI-Hilfsfunktionen des Layout-Editors – insbesonder
 - **Tests**: Änderungen an UI-Hilfen erfordern Aktualisierungen in `../../tests/ui-component.test.ts` bzw. `../../tests/ui-diff-renderer.test.ts`.
 - **Stage-Performance**: `StageComponent` nutzt Snapshot-Cursor und `store.runInteraction()`, um Pointer-Frames ohne zusätzliche `getState()`-Aufrufe oder doppelte Exporte abzuwickeln. Neue Interaktionen müssen diese Mechanik respektieren.
 
+## Kernabläufe
+
+### Fokus-Handshake Tree ⇄ Stage
+1. `StructurePanelPresenter.handleSelect()` meldet die Tree-Auswahl an den Store (siehe [`../presenters/structure-panel.ts`](../presenters/structure-panel.ts)).
+2. Der Store publiziert einen Snapshot mit aktualisierter Auswahl; `StageController` erhält ihn über `store.subscribe` und aktualisiert `StageComponent`.
+3. Direkt nach der Store-Mutation ruft der Presenter `StageController.focusElement()` auf, wodurch Kamera- und Telemetrie-Events synchron mit dem Tree laufen.
+4. `StageComponent` emittiert `focus`-Telemetrie; Analytics oder Tests abonnieren diese über `observeCamera()`.
+
+Der Soll-Workflow inklusive Nutzerperspektive ist im User-Wiki unter [Stage-Fokus & Navigation](../../../docs/stage-instrumentation.md#kamera-telemetrie) beschrieben.
+
+### Drag-Lifecycle auf der Stage
+1. Pointer-Events werden in `StageComponent` über Scope-Listener registriert.
+2. `LayoutEditorStore.runInteraction()` bündelt Move/Resize-Mutationen zu einem Frame, setzt den Export-Status dirty und liefert einen Snapshot für Stage & Tree.
+3. Nach `pointerup` ruft die Stage `store.flushExport()`, wodurch Header/Notice den finalen Export erhalten.
+4. Drag-State (`draggedElementId`) wird auf `null` zurückgesetzt; Tree- und Stage-Overlays verschwinden beim nächsten Snapshot.
+
+Aus Anwendersicht ist dieser Ablauf im [User-Wiki › Stage-Bedienkonzept](../../../docs/stage-instrumentation.md#tests--qualit%C3%A4tssicherung) dokumentiert.
+
+### Kontextmenüs & Aktionen
+1. UI-Komponenten übergeben den aktuellen Fokuskontext an `createEditorMenu()`.
+2. Das Menü baut Aktionen abhängig von Selektion, Rechtekontext und Feature-Flags.
+3. Aktionen rufen Presenter-Methoden (z. B. `StageController.deleteSelected()`) oder Store-APIs direkt auf.
+4. Persistente Folgen (Speichern, Notice) werden über den Header-Presenter gespiegelt.
+
+Für den Nutzerablauf siehe [User-Wiki › Setup-Workflows › View-Bindings](../../../docs/README.md#setup-workflows).
+
 ## Weiterführende Dokumentation
 - Architektur-Überblick: [`../README.md`](../README.md)
 - Performance-Guidelines für UI-Widgets: [`../../docs/ui-performance.md`](../../docs/ui-performance.md)
 - Projektweite Einordnung & Workflows: [`../../../README.md`](../../../README.md)
+- Nutzerzentrierte Workflows & Begriffsdefinitionen: [`../../../docs/README.md`](../../../docs/README.md)
 
 ## Offene Punkte
 
 - Dokumentationsabgleich für Interaktionen und Presenter: [`documentation-audit-ui-experience.md`](../../todo/documentation-audit-ui-experience.md).
+- Sequenzdiagramme & A11y-Kriterien ergänzen: [`ui-accessibility-and-diagrams.md`](../../todo/ui-accessibility-and-diagrams.md).

--- a/todo/README.md
+++ b/todo/README.md
@@ -10,6 +10,7 @@ Dieses Verzeichnis sammelt alle offenen To-Dos für den Layout-Editor. Jede Date
 - `documentation-audit-configuration-settings.md` – Überprüfung der Konfigurations- und Settings-Dokumentation.
 - `documentation-audit-integration-api.md` – Validierung der Integrations- und Plugin-API-Dokumente.
 - `store-snapshot-immutability-tests.md` – Regressionstest für unveränderliche Store-Snapshots.
+- `ui-accessibility-and-diagrams.md` – Sequenzdiagramme und Barrierefreiheitsrichtlinien für UI-Flows.
 
 ## Backlog-Übersicht
 
@@ -21,6 +22,7 @@ Dieses Verzeichnis sammelt alle offenen To-Dos für den Layout-Editor. Jede Date
 | [`documentation-audit-configuration-settings.md`](documentation-audit-configuration-settings.md) | Dokumentation | Mittel | Konfigurations-, Settings- und Fehlerpfad-Dokumentation abgleichen. |
 | [`documentation-audit-integration-api.md`](documentation-audit-integration-api.md) | Dokumentation | Mittel | Integrations- und Plugin-API-Guides auf Vollständigkeit prüfen. |
 | [`store-snapshot-immutability-tests.md`](store-snapshot-immutability-tests.md) | Tests | Mittel | Regressionstest sicherstellen, dass Store-Snapshots außerhalb des Stores nicht mutiert werden können. |
+| [`ui-accessibility-and-diagrams.md`](ui-accessibility-and-diagrams.md) | Dokumentation | Mittel | Sequenzdiagramme und Barrierefreiheit für UI-Flows definieren. |
 
 Sobald neuer Handlungsbedarf entsteht, lege eine eigene Markdown-Datei in diesem Ordner an und verlinke sie in dieser Tabelle nach Priorität.
 

--- a/todo/ui-accessibility-and-diagrams.md
+++ b/todo/ui-accessibility-and-diagrams.md
@@ -1,0 +1,31 @@
+---
+status: open
+priority: medium
+area: documentation
+owner: unassigned
+tags:
+  - ui
+  - accessibility
+  - diagrams
+---
+
+# Sequenzdiagramme & Barrierefreiheit für UI-Flows
+
+## Originalkritik
+- Die technischen Readmes beschreiben Stage-, Tree- und Header-Flows textuell, aber es fehlen verbindliche Sequenzdiagramme und Zustandsübersichten für kritische Interaktionen (z. B. Fokus-Handshake, Drag-Lifecycle, Persistenz-Feedback).
+- Anforderungen zur Barrierefreiheit (Keyboard-Navigation, ARIA-Rollen, Kontrast) werden weder im User-Wiki noch in Modul-Dokumentationen konkretisiert.
+
+## Kontext
+- Betrifft die UI-Schichten `src/ui`, `src/presenters` sowie die Elements-Implementierungen, da dort Interaktionszustände und DOM-Semantik definiert werden.
+- Nutzer:innen-Workflows im User-Wiki referenzieren diese Interaktionen, weshalb fehlende Diagramme und A11y-Kriterien aktuell nicht mit dem Soll-Zustand abgeglichen werden können.
+
+## Betroffene Module
+- `layout-editor/src/ui` – Komponenten und DOM-Baum für Stage, Tree und Menüs.
+- `layout-editor/src/presenters` – Orchestriert Fokus, Drag-Sequenzen und Persistenzhinweise.
+- `layout-editor/src/elements` – Liefert die konkreten UI-Bausteine für Stage & Inspector samt eventueller ARIA-/Keyboard-Hooks.
+- User-Wiki (`docs/stage-instrumentation.md`, `docs/README.md`) – Muss die visualisierten Abläufe aufnehmen und den Soll-Zustand für Barrierefreiheit beschreiben.
+
+## Lösungsideen
+- Sequenzdiagramme (PlantUML oder Mermaid) für Fokus-Handshake Tree ⇄ Stage, Drag-Reparenting und Persistenzfehler-Flows erstellen und in den passenden Modul-Readmes einbetten.
+- Accessibility-Guideline erarbeiten (Rollen, Tastatursteuerung, visuelle Zustände), in den Modul-Dokumenten verankern und im User-Wiki konsolidieren.
+- Review-Checklist ergänzen, damit neue UI-Features Diagramme und A11y-Kriterien dokumentiert haben, bevor sie gemerged werden.


### PR DESCRIPTION
## Summary
- document structural overview and core interaction sequences for the UI, elements, and presenter layers, linking them to the user-facing wiki
- extend UI performance and layout library guides with stepwise flows and user wiki cross-references
- add a new backlog entry for missing interaction diagrams and accessibility standards, updating the todo index accordingly

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d79e2dd534832581105e7009a80a24