### PR TITLE
Add regression coverage for store snapshot immutability

### DIFF
--- a/layout-editor/tests/history-limits.test.ts
+++ b/layout-editor/tests/history-limits.test.ts
@@ -64,7 +64,14 @@ async function testHistoryCapAndRedoIntegrity() {
     assert.equal(current.elements[0]?.label, "Label 5", "undo should stop at bounded baseline");
     assert.equal(history.canUndo, false, "history should not allow undo past retained window");
 
+    // Regression für das geschlossene To-Do "store-snapshot-immutability-tests":
+    // Mutationen an History-Snapshots dürfen beim Redo nicht auftauchen.
+    current.canvasHeight = 4242;
     current.elements[0]!.label = "Mutated outside history";
+    current.elements[0]!.attributes.push("rogue");
+    current.elements[0]!.children = ["ghost-child"];
+    current.elements[0]!.layout = { gap: 123, padding: 5, align: "stretch" };
+    current.elements[0]!.viewState = { injected: true };
     current.elements.push({
         ...ELEMENT_TEMPLATE,
         id: "temp",


### PR DESCRIPTION
## Summary
- extend the layout editor store regression to mutate deep snapshot structures and verify the cloned state
- guard the history redo path against externally mutated snapshots to ensure redo results remain intact

## Testing
- not run (Node.js runtime is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d79f429d4c832582af9d37fff52692