### PR TITLE
Document UI components in the user wiki

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Dieses Verzeichnis bündelt die nutzerorientierten Ergänzungen zum technischen 
 - [`api-migrations.md`](api-migrations.md) – Leitfaden für API-Änderungen, Layout-Schema-Migrationen sowie Qualitätschecks rund um Versionssprünge.
 - [`persistence-diagnostics.md`](persistence-diagnostics.md) – Monitoring-Checks und Leitplanken für Speicherintegrität im Clusterbetrieb.
 - [`stage-instrumentation.md`](stage-instrumentation.md) – Messpunkte, KPIs und Alarmierungs-Setup für Deploy- und Preview-Stages.
+- [`ui-components.md`](ui-components.md) – Soll-Referenz aller sichtbaren UI-Komponenten (Stage, Strukturbaum, Inspector, Banner, Menüs) inklusive Interaktionsmuster und bekannten Lücken.
 
 ## Setup-Workflows
 
@@ -26,6 +27,12 @@ Dieses Verzeichnis bündelt die nutzerorientierten Ergänzungen zum technischen 
 - Schnellstart für Fehlersuche in der Layout-Persistenz liefert [`persistence-diagnostics.md`](persistence-diagnostics.md); technische Details befinden sich in [`layout-editor/docs/persistence-errors.md`](../layout-editor/docs/persistence-errors.md).
 - Für View-Probleme Verweise auf [`layout-editor/docs/view-registry.md#diagnose--fehlerbehebung`](../layout-editor/docs/view-registry.md#diagnose--fehlerbehebung) verwenden.
 - Stage- und CI-Anforderungen sind in [`stage-instrumentation.md`](stage-instrumentation.md) sowie im [Tooling-Guide](../layout-editor/docs/tooling.md#tooling--ci-anforderungen) gebündelt.
+
+## UI-Komponenten im Überblick
+
+- Nutze [`ui-components.md`](ui-components.md) als zentrale Soll-Referenz für Stage, Strukturbaum, Inspector, Banner und Menüs.
+- Detailfragen zu Kamera und Rendering beantwortet [`stage-instrumentation.md`](stage-instrumentation.md) sowie [`../layout-editor/docs/ui-performance.md`](../layout-editor/docs/ui-performance.md).
+- Offene UX- und Accessibility-Aspekte sind als To-Dos verlinkt; das User-Wiki selbst dokumentiert nur den Soll-Zustand.
 
 ## Verwandte Deep-Dives in `layout-editor/docs/`
 
@@ -49,3 +56,7 @@ Dieses Verzeichnis bündelt die nutzerorientierten Ergänzungen zum technischen 
 
 - Integrations-Guides gegen Soll-Zustand prüfen: [`documentation-audit-integration-api.md`](../todo/documentation-audit-integration-api.md).
 - Runtime-Voraussetzungen für Entwickler dokumentieren: [`onboarding-runtime-compatibility.md`](../todo/onboarding-runtime-compatibility.md).
+- Accessibility-Standards für UI-Komponenten definieren: [`ui-component-accessibility-spec.md`](../todo/ui-component-accessibility-spec.md).
+- Rollen- und Berechtigungskonzept im Inspector fixieren: [`ui-component-inspector-permissions.md`](../todo/ui-component-inspector-permissions.md).
+- Eskalationspfad für Statusmeldungen beschreiben: [`ui-component-status-ux-gaps.md`](../todo/ui-component-status-ux-gaps.md).
+- Kontextmenü-Inventar vervollständigen: [`ui-component-menu-inventory.md`](../todo/ui-component-menu-inventory.md).

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -1,0 +1,210 @@
+# UI-Komponenten des Layout-Editors – Soll-Referenz
+
+Diese Seite dokumentiert den erwarteten Funktionsumfang der sichtbaren Editor-Bausteine. Sie ergänzt die technischen Detailbeschreibungen in `layout-editor/docs/` und dient als verbindlicher Abgleich für Produkt, QA und Entwicklung.
+
+## Navigationshilfe
+
+- [Stage (Canvas)](#stage-canvas)
+- [Strukturbaum](#strukturbaum)
+- [Inspector-Panel](#inspector-panel)
+- [Status-Banner](#status-banner)
+- [Editor-Hülle & Resizer](#editor-hülle--resizer)
+- [Menüs & Kontextaktionen](#menüs--kontextaktionen)
+
+> 💡 **Technische Deep-Dives**: Siehe insbesondere [`layout-editor/src/ui/components/README.md`](../layout-editor/src/ui/components/README.md) für den Komponentenüberblick, [`layout-editor/docs/ui-performance.md`](../layout-editor/docs/ui-performance.md) für Render- und Diff-Verhalten sowie [`docs/stage-instrumentation.md`](stage-instrumentation.md) für Telemetrie.
+
+## Stage (Canvas)
+
+**Zweck:** Visualisiert das aktive Layout, ermöglicht direkte Manipulation von Elementen und steuert die Kamera. Verantwortlich ist [`StageComponent`](../layout-editor/src/ui/components/stage.ts).
+
+### Interaktionsmuster
+
+1. **Auswahl & Kontextwechsel**
+   - Klick auf leeren Canvas setzt die Auswahl zurück (`onSelectElement(null)`).
+   - Klick auf ein Element setzt `is-selected` und synchronisiert Strukturbaum & Inspector.
+   - Inline-Mutationen (z. B. direktes Editieren über Previews) schließen mit `finalizeInlineMutation` ab, damit Store, Layout und Export konsistent bleiben.
+2. **Bewegen & Begrenzen**
+   - Drag startet nach `pointerdown` und hält das Element innerhalb der Canvas-Abmessungen (`clamp` auf `canvasWidth`/`canvasHeight`).
+   - Container-Bewegungen triggern zusätzlich `applyContainerLayout` für Eltern.
+3. **Größenänderung**
+   - Resize-Griffe wechseln abhängig von Ecke den Cursor (`nwse-resize`/`nesw-resize`).
+   - Mindestgröße entspricht `MIN_ELEMENT_SIZE`; Container aktualisieren abhängige Layouts.
+4. **Kamera**
+   - Erstinitialisierung erfolgt lazy nach `requestAnimationFrame`, Ziel ist `StageCameraCenterEvent` mit `reason: "initial"`.
+   - Zoom (`wheel`) und Scroll/Pan (`pointermove` bei gedrückter Mitteltaste) emittieren Observer-Ereignisse für Telemetrie (`observeCamera`).
+
+### Zustände
+
+| Zustand | Beschreibung | Sichtbares Verhalten |
+| --- | --- | --- |
+| Initialisierung | Renderer erstellt DOM und wartet auf erstes `syncStage`. | Canvas leer, Kamera wird nachgelagert zentriert. |
+| Auswahl aktiv | `selectedElementId` gesetzt. | Box mit `is-selected`-Klasse, Inspector zeigt Elementdetails. |
+| Interaktion (Move/Resize) | `is-interacting` auf Element. | Cursor wechselt; Stage sperrt weitere Interaktionen bis Cleanup. |
+| Kamera-Fokus | `focusElement` aufgerufen. | Kamera zentriert Ziel, `reason: "focus"` für Observer. |
+
+### Verweise
+
+- Renderpfad & Diffing: [`layout-editor/src/ui/components/diff-renderer.ts`](../layout-editor/src/ui/components/diff-renderer.ts).
+- Kamera-Telemetrie & Metriken: [`docs/stage-instrumentation.md`](stage-instrumentation.md#kamera-telemetrie).
+- Performance-Anforderungen: [`layout-editor/docs/ui-performance.md`](../layout-editor/docs/ui-performance.md#stage-component).
+
+### Bekannte Lücken
+
+- Barrierefreiheit (Tastaturnavigation & Screenreader-Ankündigungen) ist nicht spezifiziert → siehe [`todo/ui-component-accessibility-spec.md`](../todo/ui-component-accessibility-spec.md).
+
+## Strukturbaum
+
+**Zweck:** Spiegelt die Layout-Hierarchie, ermöglicht Auswahl, Reparenting und Reordering. Implementiert durch [`StructureTreeComponent`](../layout-editor/src/ui/components/structure-tree.ts).
+
+### Interaktionsmuster
+
+1. **Auswahl** – Klick auf `button.sm-le-structure__entry` ruft `onSelect` und synchronisiert Stage/Inspector.
+2. **Drag & Drop**
+   - Root-Dropzone erscheint, sobald Elemente vorhanden sind; erlaubt das Ablösen (`onReparent` mit `parentId: null`).
+   - Kinder-Listen folgen der Modellreihenfolge (`children` des LayoutElements); Reorder sendet `onReorder` mit Ziel-ID und Position.
+   - Während Drag markiert `onDragStateChange` Quell-Element und Zielzonen.
+3. **Leerer Zustand** – Ohne Elemente zeigt `sm-le-empty` den Hinweis „Noch keine Elemente.“
+
+### Zustände
+
+| Zustand | Auslöser | Darstellung |
+| --- | --- | --- |
+| Leer | `elements.length === 0` | Nur leerer Hinweis, keine Dropzone. |
+| Drop verfügbar | Drag gestartet & Container erlaubt | Aktive Dropzone (`is-active` auf Wurzel/Eintrag). |
+| Selektion | `selectedId` gesetzt | Entry trägt `is-selected`, Stage-Highlight synchron. |
+| Dragging | `draggedElementId` gesetzt | Entry markiert, Drop-Hinweise sichtbar. |
+
+### Verweise
+
+- Container-Gültigkeit & Constraints: [`layout-editor/docs/layout-library.md`](../layout-editor/docs/layout-library.md#layout-tree-service).
+- Historie & Store-Interaktion: [`layout-editor/docs/data-model-overview.md`](../layout-editor/docs/data-model-overview.md#store-integration).
+- Testszenarien: [`layout-editor/tests/ui-component.test.ts`](../layout-editor/tests/ui-component.test.ts) und [`layout-editor/tests/ui-diff-renderer.test.ts`](../layout-editor/tests/ui-diff-renderer.test.ts) für Drag/Render-Verhalten.
+
+### Bekannte Lücken
+
+- Reihenfolge der Tastatur-Fokusnavigation im Baum ist offen → [`todo/ui-component-accessibility-spec.md`](../todo/ui-component-accessibility-spec.md).
+
+## Inspector-Panel
+
+**Zweck:** Zeigt und editiert Eigenschaften des selektierten Elements. Der Funktionsumfang wird von [`renderInspectorPanel`](../layout-editor/src/inspector-panel.ts) bereitgestellt.
+
+### Interaktionsmuster
+
+1. **Leerer Zustand** – Ohne Auswahl erscheint `strings.inspector.emptyState` als Hinweis.
+2. **Kontextinfo** – Oben `sm-le-meta` mit Typlabel, darunter Hinweistext (`strings.inspector.hint`).
+3. **Container-Zuweisung** – Dropdown listet alle Container, blockiert Vorfahren/Abkömmlinge (`collectAncestorIds`/`collectDescendantIds`).
+4. **Attribut-Übersicht** – Read-only Chip `sm-le-attr` fasst Attribute zusammen (`getAttributeSummary`).
+5. **Aktionen** – `Löschen`-Button (Warn-Variante) ruft `deleteElement`.
+6. **Dimension & Position** – Inline-Felder für `width`, `height`, `x`, `y` mit Grenzwerten (`MIN_ELEMENT_SIZE`, Canvasgrenzen). Änderungen synchronisieren Store, Export & Layout (`applyContainerLayout`).
+7. **Custom Sections** – Komponenten-spezifische Controls werden über `getLayoutElementComponent` injiziert.
+
+### Zustände
+
+| Zustand | Beschreibung |
+| --- | --- |
+| Keine Auswahl | Inspector zeigt nur Heading & Empty-State-Hinweis. |
+| Container | Zusätzliche Container-spezifische Felder aktiv; `ensureContainerDefaults` wird aufgerufen. |
+| Read-only Felder | Nicht implementiert – pending Accessibility/Permissions-Konzept. |
+
+### Verweise
+
+- Lokalisierung: [`layout-editor/docs/i18n.md`](../layout-editor/docs/i18n.md#injecting-strings-into-presenters).
+- Element-Komponenten: [`layout-editor/docs/view-registry.md`](../layout-editor/docs/view-registry.md).
+- Store-Abläufe: [`layout-editor/docs/data-model-overview.md`](../layout-editor/docs/data-model-overview.md#store-integration).
+
+### Bekannte Lücken
+
+- Rollenspezifische Felder (Read-only vs. editierbar) fehlen in der Soll-Dokumentation → [`todo/ui-component-inspector-permissions.md`](../todo/ui-component-inspector-permissions.md).
+
+## Status-Banner
+
+**Zweck:** Kommuniziert kritische Statusinformationen (Speicherstand, Validierung, Ratelimits). Implementiert durch [`StatusBannerComponent`](../layout-editor/src/ui/components/status-banner.ts).
+
+### Interaktionsmuster
+
+1. **Ein-/Ausblenden** – `setState(null)` versteckt das Banner vollständig (`display: none`).
+2. **Tonwahl** – `tone` bestimmt CSS-Modifikator `sm-le-status-banner--{tone}`.
+3. **Details** – Optionale Liste (`<dl>`) aus `details`-Tuple (Label/Wert). Wird nur angezeigt, wenn vorhanden.
+4. **Beschreibung** – Freitext-Zusatz unterhalb des Titels.
+
+### Zustände
+
+| Zustand | Beschreibung |
+| --- | --- |
+| Versteckt | Keine aktiven Statusmeldungen. |
+| Info | Standardhinweis, z. B. Autosave aktiv. |
+| Success | Abschluss-Meldungen (z. B. Export erfolgreich). |
+| Warning | Nicht-blockierende Probleme (Quota nahe Limit). |
+| Danger | Kritische Fehler, häufig gepaart mit Modal oder Blocker. |
+
+### Verweise
+
+- Fehlerbehebung & Persistenz: [`docs/persistence-diagnostics.md`](persistence-diagnostics.md).
+- Telemetrie & Monitoring: [`docs/stage-instrumentation.md`](stage-instrumentation.md).
+
+### Bekannte Lücken
+
+- Eskalationspfad (wann Banner vs. Dialog) unklar → [`todo/ui-component-status-ux-gaps.md`](../todo/ui-component-status-ux-gaps.md).
+
+## Editor-Hülle & Resizer
+
+**Zweck:** Das `EditorShellComponent` verwaltet Struktur-Panel, Stage und Inspector inklusive Resizer-Logik und Panel-Breiten.
+
+### Interaktionsmuster
+
+1. **Panel-Initialisierung** – Panels übernehmen `initialSizes`; `applyPanelSizes` setzt Flex-Basis.
+2. **Resizer** – Drag über `sm-le-resizer` (mit `role="separator"`, `aria-orientation="vertical"`). PointerCapture sorgt für konsistente Interaktion.
+3. **Minimale Breite** – `minPanelWidth` & `minStageWidth` verhindern, dass Stage kollabiert.
+4. **Persistenz** – `onResizePanels` Callback informiert Store/Settings zum Speichern.
+5. **Header-Host** – `getHeaderHost()` stellt Aufnahmeort für Toolbars/Banner bereit.
+
+### Zustände
+
+| Zustand | Beschreibung |
+| --- | --- |
+| Standard | Panels auf Initialwerten. |
+| Resizing | Aktiver Resizer trägt `is-active`. |
+| Persistiert | Externe Consumer speichern Werte; Shell reflektiert bei `setPanelSizes`.
+
+### Verweise
+
+- Technische Layout-Details: [`layout-editor/src/ui/components/editor-shell.ts`](../layout-editor/src/ui/components/editor-shell.ts).
+- Tooling zur Panel-Persistenz: [`layout-editor/docs/tooling.md`](../layout-editor/docs/tooling.md).
+
+### Bekannte Lücken
+
+- Kein definierter Fokusrahmen für Tastatur-Resize → [`todo/ui-component-accessibility-spec.md`](../todo/ui-component-accessibility-spec.md).
+
+## Menüs & Kontextaktionen
+
+**Zweck:** Kontextmenüs, Trigger über Buttons oder rechte Maustaste. Zentral verwaltet durch [`openEditorMenu`](../layout-editor/src/ui/editor-menu.ts).
+
+### Interaktionsmuster
+
+1. **Öffnen** – Menü erhält `anchor`, optionale Mausposition (`event`). Bereits offene Menüs schließen zuerst.
+2. **Navigation** – Erstes aktivierbares Item erhält Fokus. ESC oder Blur schließen Menü.
+3. **Items** – Unterstützt `item` (Label, optionale Beschreibung, `disabled`) und `separator`.
+4. **Schließen** – Pointer außerhalb von Menü & Anker oder `onSelect` beenden Menü.
+
+### Zustände
+
+| Zustand | Beschreibung |
+| --- | --- |
+| Geschlossen | Kein Menü aktiv (`activeMenu === null`). |
+| Offen | Menü im DOM, globale Listener aktiv. |
+| Deaktiviertes Item | Item trägt `is-disabled`, reagiert nicht auf Klick/Enter/Space. |
+
+### Verweise
+
+- UI-Primitives: [`layout-editor/src/ui/components/primitives.ts`](../layout-editor/src/ui/components/primitives.ts).
+- Workflow-Integration: [`docs/api-migrations.md`](api-migrations.md) für release-relevante Änderungen.
+
+### Bekannte Lücken
+
+- Vollständige Auflistung aller Menüs und Triggerpunkte fehlt → [`todo/ui-component-menu-inventory.md`](../todo/ui-component-menu-inventory.md).
+
+## Weiteres Vorgehen
+
+- Neue Komponenten müssen diese Struktur übernehmen (Zweck, Interaktion, Zustände, Verweise, Lücken).
+- Querverweise zu technischen Spezifikationen sind Pflicht, damit Implementierung & Wiki konsistent bleiben.
+- Offene Punkte werden ausschließlich im `todo/`-Ordner gepflegt (siehe oben verlinkte Dateien).

--- a/layout-editor/src/ui/components/README.md
+++ b/layout-editor/src/ui/components/README.md
@@ -1,6 +1,6 @@
 # UI-Komponenten
 
-Die Komponenten in diesem Ordner implementieren die interaktiven Widgets der Canvas-Ansicht. Sie folgen dem `UIComponent`-Pattern, um DOM-Lebenszyklen und Eventlistener deterministisch zu verwalten.
+Die Komponenten in diesem Ordner implementieren die interaktiven Widgets der Canvas-Ansicht. Sie folgen dem `UIComponent`-Pattern, um DOM-Lebenszyklen und Eventlistener deterministisch zu verwalten. Eine nutzerorientierte Soll-Dokumentation der sichtbaren Komponenten findest du im User-Wiki unter [`docs/ui-components.md`](../../../docs/ui-components.md).
 
 ## Inhalte
 - [`component.ts`](component.ts) – Basisklasse `UIComponent` inkl. `UIComponentScope`, Listener-Verwaltung und `renderComponent`-Helper.
@@ -26,9 +26,13 @@ Die Komponenten in diesem Ordner implementieren die interaktiven Widgets der Can
 - Kombiniere Scope-Hilfen mit komponentenweiten `registerCleanup`-Einträgen: globale Listener bleiben am Komponenten-Scope, Knoten-spezifische Ressourcen hängen am Diff-Kontext und werden durch den Renderer freigegeben.
 
 ## Offene Aufgaben
-- [To-Do: UI-Komponenten-Wiki vervollständigen](../../../../todo/ui-components-wiki.md)
+- Accessibility-Spezifikation für Stage, Strukturbaum und Resizer ergänzen: [`ui-component-accessibility-spec.md`](../../../../todo/ui-component-accessibility-spec.md)
+- Rollen- und Berechtigungskonzept des Inspectors definieren: [`ui-component-inspector-permissions.md`](../../../../todo/ui-component-inspector-permissions.md)
+- Eskalationsregeln für Status-Banner dokumentieren: [`ui-component-status-ux-gaps.md`](../../../../todo/ui-component-status-ux-gaps.md)
+- Kontextmenü-Inventar vervollständigen: [`ui-component-menu-inventory.md`](../../../../todo/ui-component-menu-inventory.md)
 
 ## Weiterführende Dokumentation
+- User-Wiki-Referenz der UI-Komponenten: [`../../../docs/ui-components.md`](../../../docs/ui-components.md)
 - Canvas- und Rendering-Details: [`../../docs/ui-performance.md`](../../docs/ui-performance.md)
 - Architektur des `src`-Moduls: [`../../README.md`](../../README.md)
 - Projektweiter Kontext: [`../../../README.md`](../../../README.md)

--- a/todo/ui-component-accessibility-spec.md
+++ b/todo/ui-component-accessibility-spec.md
@@ -1,0 +1,40 @@
+---
+status: open
+priority: high
+area:
+  - documentation
+  - accessibility
+owner: unassigned
+tags:
+  - ui-components
+  - keyboard
+links:
+  - docs/ui-components.md
+  - layout-editor/src/ui/components/stage.ts
+  - layout-editor/src/ui/components/structure-tree.ts
+  - layout-editor/src/ui/components/editor-shell.ts
+---
+
+# UI-Komponenten – Accessibility-Spezifikation
+
+## Originalkritik
+- Die neue User-Wiki-Referenz benennt mehrere Komponenten mit fehlender Tastaturführung und Screenreader-Strategie.
+- Bisher existiert kein verbindlicher Soll-Zustand für Fokusreihenfolge, ARIA-Rollen oder Keyboard-Shortcuts der Stage, Resizer und Strukturbaum.
+
+## Kontext
+- QA und Accessibility-Audits benötigen dokumentierte Regeln, um Interaktionen zu testen und Abweichungen zu melden.
+- Ohne Vorgaben laufen zukünftige Implementierungen Gefahr, inkompatible oder nicht-barrierefreie Patterns einzuführen.
+- Resizer besitzen zwar ARIA-Attribute, aber Fokusverhalten und Feedback bei Grenzen sind ungeregelt.
+
+## Betroffene Module
+- `docs/ui-components.md`
+- `layout-editor/src/ui/components/stage.ts`
+- `layout-editor/src/ui/components/structure-tree.ts`
+- `layout-editor/src/ui/components/editor-shell.ts`
+- Potenzielle Tests in `layout-editor/src/tests/`
+
+## Lösungsideen
+- Accessibility-Guideline schreiben: Fokuspfad, Tastenkombinationen, Screenreader-Texte, Live-Regionen für Banner.
+- Ergänzende UI-Tests definieren (z. B. Playwright oder Jest mit jsdom) für Keyboard-Interaktionen.
+- Abstimmen mit `ui-accessibility-and-diagrams.md`, damit Diagramme & Texte konsistent bleiben.
+- Nach Fertigstellung User-Wiki aktualisieren und hierher verlinkte Hinweise entfernen.

--- a/todo/ui-component-inspector-permissions.md
+++ b/todo/ui-component-inspector-permissions.md
@@ -1,0 +1,38 @@
+---
+status: open
+priority: medium
+area:
+  - documentation
+  - product
+owner: unassigned
+tags:
+  - ui-components
+  - inspector
+links:
+  - docs/ui-components.md
+  - layout-editor/src/inspector-panel.ts
+  - layout-editor/docs/data-model-overview.md
+---
+
+# Inspector-Panel – Rollen & Berechtigungen klären
+
+## Originalkritik
+- Das User-Wiki weist darauf hin, dass Read-only-Zustände und Rollentrennungen im Inspector nicht definiert sind.
+- Produktentscheidungen zu Admin-/Viewer-Rollen wurden bisher nur mündlich kommuniziert und fehlen schriftlich.
+
+## Kontext
+- Ohne klare Spezifikation können Implementierungen versehentlich Schreibrechte für Nutzer gewähren, die nur lesen dürfen.
+- QA benötigt eindeutige Regeln, um das Verhalten im Review zu validieren.
+- Integrationen mit Fremdsystemen (z. B. Freigabeworkflows) hängen von verlässlichen Berechtigungsmodellen ab.
+
+## Betroffene Module
+- `layout-editor/src/inspector-panel.ts`
+- `layout-editor/src/state/layout-editor-store.ts`
+- User-Wiki (`docs/ui-components.md`)
+- Mögliche Feature-Flags/Settings in `layout-editor/docs/tooling.md`
+
+## Lösungsideen
+- Rollenmodell festlegen (z. B. Viewer, Editor, Admin) und definieren, welche Felder editierbar bleiben.
+- Read-only-Varianten der Eingabefelder in `inspector-panel.ts` entwerfen (Disabled-State, Tooltip mit Hinweis).
+- Dokumentation im User-Wiki erweitern, sobald Konzept steht; To-Do danach entfernen.
+- Ergänzende Regressionstests schreiben (Snapshot oder Interaktion), um Schreibversuche ohne Rechte abzufangen.

--- a/todo/ui-component-menu-inventory.md
+++ b/todo/ui-component-menu-inventory.md
@@ -1,0 +1,38 @@
+---
+status: open
+priority: medium
+area:
+  - documentation
+  - ux
+owner: unassigned
+tags:
+  - ui-components
+  - menus
+links:
+  - docs/ui-components.md
+  - layout-editor/src/ui/editor-menu.ts
+  - layout-editor/src/elements/registry.ts
+---
+
+# Kontextmenüs – Inventur & Trigger-Dokumentation
+
+## Originalkritik
+- Im User-Wiki fehlen konkrete Listen, welche Kontextmenüs existieren und wodurch sie geöffnet werden.
+- Entwickler:innen müssen aktuell den Code durchsuchen, um Menüeinträge zu finden; das erschwert Reviews und Onboarding.
+
+## Kontext
+- Neue Komponenten sollen konsistente Menüs erhalten; ohne Inventur droht Duplizierung oder widersprüchliche Bezeichnungen.
+- QA benötigt eine Referenz, um fehlende oder fehlerhafte Menüeinträge zu erkennen.
+- Lokalisierungsteams brauchen Überblick, um Strings zu priorisieren (`layout-editor/docs/i18n.md`).
+
+## Betroffene Module
+- `layout-editor/src/ui/editor-menu.ts`
+- `layout-editor/src/elements/`
+- User-Wiki (`docs/ui-components.md`)
+- Tests in `layout-editor/src/tests/`
+
+## Lösungsideen
+- Vollständige Liste aller Menü-Triggers (Buttons, Kontextaktionen, Tastaturkürzel) erstellen.
+- Menüeinträge kategorisieren (Layout-Manipulation, Export, History etc.) und im User-Wiki dokumentieren.
+- Prüfen, ob dedizierte Tests für Menü-Inhalte sinnvoll sind (Snapshot/Contract-Test).
+- Nach Pflege Inventur im User-Wiki verlinken und dieses To-Do schließen.

--- a/todo/ui-component-status-ux-gaps.md
+++ b/todo/ui-component-status-ux-gaps.md
@@ -1,0 +1,38 @@
+---
+status: open
+priority: medium
+area:
+  - documentation
+  - ux
+owner: unassigned
+tags:
+  - ui-components
+  - status-banner
+links:
+  - docs/ui-components.md
+  - docs/persistence-diagnostics.md
+  - layout-editor/src/ui/components/status-banner.ts
+---
+
+# Status-Banner – Eskalationsregeln definieren
+
+## Originalkritik
+- Der User-Wiki-Eintrag beschreibt mögliche Banner-Töne, aber keine Richtlinien, wann stattdessen Dialoge, Toasts oder Modals eingesetzt werden.
+- Aktuell fehlt ein konsistenter Eskalationspfad zwischen Warnungen, Fehlern und Blockern.
+
+## Kontext
+- Ohne klare Eskalationsregeln entstehen divergierende UX-Muster, wenn Teams neue Statusmeldungen hinzufügen.
+- Support benötigt Vorgaben, ab wann Benutzer aktiv aufgehalten oder informiert werden müssen.
+- Monitoring/Telemetry (siehe `stage-instrumentation.md`) kann nur sinnvoll ausgewertet werden, wenn die Bedeutung der Töne dokumentiert ist.
+
+## Betroffene Module
+- `layout-editor/src/ui/components/status-banner.ts`
+- User-Wiki (`docs/ui-components.md`)
+- `docs/persistence-diagnostics.md`
+- Mögliche Modalkomponenten (`layout-editor/src/ui/*`)
+
+## Lösungsideen
+- Eskalationsmatrix erstellen (Banner vs. Modal vs. Blocking-Screen) mit Beispielszenarien.
+- Dokumentierte KPI-Schwellenwerte aus `persistence-diagnostics.md` integrieren.
+- UX-Guideline veröffentlichen und in User-Wiki verlinken, Banner-Eintrag aktualisieren.
+- Ergänzende Playbook-Checkliste für Support-/Oncall-Teams erstellen.


### PR DESCRIPTION
## Summary
- add a comprehensive user-facing reference for stage, structure tree, inspector, banner, shell and menu components
- cross-link the docs index and technical UI component README with the new wiki entry
- capture outstanding UX, accessibility and permissions gaps as dedicated todo tickets

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d7a23c1dd0832583d3aa46713e0e7d