### PR TITLE
Update UI documentation and track shortcut coverage

### DIFF
--- a/layout-editor/docs/README.md
+++ b/layout-editor/docs/README.md
@@ -19,7 +19,7 @@ related background material.
 
 ## To-Do
 
-- UI-Workflows und Interaktionen vollständig dokumentieren: [`documentation-audit-ui-experience.md`](../todo/documentation-audit-ui-experience.md).
+- Shortcut-Workflows automatisiert testen: [`ui-shortcut-coverage.md`](../todo/ui-shortcut-coverage.md).
 - Konfigurations- und Fehlerpfad-Dokumentation abgleichen: [`documentation-audit-configuration-settings.md`](../todo/documentation-audit-configuration-settings.md).
 - Integrations- und API-Guides aktualisieren: [`documentation-audit-integration-api.md`](../todo/documentation-audit-integration-api.md).
 

--- a/layout-editor/docs/layout-library.md
+++ b/layout-editor/docs/layout-library.md
@@ -8,6 +8,14 @@ Die Layout-Bibliothek kapselt das Speichern und Laden von Layout-Dateien im Obsi
 - **Legacy-Pfade:** Beim Lesen werden zusätzlich ältere Verzeichnisnamen wie `Layout Editor/Layouts` durchsucht. Dateien aus Legacy-Pfaden werden erkannt, ohne dass sie sofort migriert werden müssen.【F:layout-editor/src/layout-library.ts†L28-L157】
 - **Dateisuche:** Beim Auflisten oder Laden prüft die Bibliothek alle bekannten Ordner, filtert JSON-Dateien und ignoriert doppelte Basenamen, damit eine Layout-ID nur einmal auftaucht.【F:layout-editor/src/layout-library.ts†L133-L158】
 
+## Dokumentationsinventar
+
+| Thema | Technische Quelle | Tests & Soll-Referenzen |
+| --- | --- | --- |
+| Layout speichern & laden | [`src/layout-library.ts`](../src/layout-library.ts) | [`../tests/persistence-errors.test.ts`](../tests/persistence-errors.test.ts), [User-Wiki › Fehlerdiagnose](../../docs/README.md#fehlerdiagnose--qualit%C3%A4tschecks) |
+| Schema-Migrationen | [`runLayoutSchemaMigrations`](../src/layout-library.ts) | [`../tests/api-versioning.test.ts`](../tests/api-versioning.test.ts) |
+| Header-Integration | [`src/presenters/header-controls.ts`](../src/presenters/header-controls.ts) | [UI-Performance › Header controls feedback](./ui-performance.md#header-controls-feedback) |
+
 ## Dateinamen, IDs und Namensgebung
 
 - **Dateinamen:** Jede Layout-Datei trägt die Form `<id>.json`. Die ID ist damit der primäre Schlüssel im Vault.【F:layout-editor/src/layout-library.ts†L160-L200】
@@ -54,7 +62,7 @@ Bei Erfolg werden Metadaten wie `createdAt`, `updatedAt` und `schemaVersion` ges
 
 ### `saveLayoutToLibrary`
 
-- **Banner & Notices:** Fehler propagieren bis zur Kopfzeile des Editors. `describeLayoutPersistenceError` ordnet bekannte Meldungen den UI-Codes `layout/...` zu, ergänzt Hilfetexte und zeigt sie sowohl im Persistenz-Banner als auch in einem Obsidian-Notice an.【F:layout-editor/src/presenters/header-controls.ts†L40-L145】【F:layout-editor/src/presenters/header-controls.ts†L400-L426】
+- **Banner & Notices:** Fehler propagieren bis zur Kopfzeile des Editors. `describeLayoutPersistenceError` ordnet bekannte Meldungen den UI-Codes `layout/...` zu, ergänzt Hilfetexte und zeigt sie sowohl im Persistenz-Banner als auch in einem Obsidian-Notice an.【F:layout-editor/src/presenters/header-controls.ts†L40-L145】【F:layout-editor/src/presenters/header-controls.ts†L400-L426】 Abgedeckt durch [`../tests/persistence-errors.test.ts`](../tests/persistence-errors.test.ts).
 - **Banner-Lifecycle:** `showPersistenceError` initialisiert bei Bedarf den `StatusBannerComponent` und aktualisiert seinen Zustand, bis ein erfolgreicher Speichervorgang `clearPersistenceError` aufruft.【F:layout-editor/src/presenters/header-controls.ts†L446-L461】
 
 ### `runLayoutSchemaMigrations`
@@ -70,5 +78,5 @@ Bei Erfolg werden Metadaten wie `createdAt`, `updatedAt` und `schemaVersion` ges
 
 ## Offene Aufgaben
 
-- Workflow-Dokumentation zwischen Bibliothek und UI prüfen: [`documentation-audit-ui-experience.md`](../todo/documentation-audit-ui-experience.md).
 - Sequenzdiagramme & Accessibility-Kriterien nachziehen: [`ui-accessibility-and-diagrams.md`](../todo/ui-accessibility-and-diagrams.md).
+- Shortcut-Testabdeckung ergänzen (Header-Shortcuts spiegeln Bibliotheksstatus): [`ui-shortcut-coverage.md`](../todo/ui-shortcut-coverage.md).

--- a/layout-editor/docs/ui-performance.md
+++ b/layout-editor/docs/ui-performance.md
@@ -2,6 +2,15 @@
 
 The component layer now renders through a lightweight diffing helper that keeps DOM mutations scoped to the elements that actually changed. This section captures the important pieces so future updates stay aligned with the incremental architecture.
 
+## Dokumentationsinventar
+
+| Thema | Technische Quelle | Ergänzende Module |
+| --- | --- | --- |
+| Diff-Rendering & Lifecycle | [`../src/ui/components/diff-renderer.ts`](../src/ui/components/diff-renderer.ts), [`../src/ui/components/component.ts`](../src/ui/components/component.ts) | Tests: [`../tests/ui-diff-renderer.test.ts`](../tests/ui-diff-renderer.test.ts) |
+| Stage-Rendering & Kamera | [`../src/ui/components/stage.ts`](../src/ui/components/stage.ts), [`../src/presenters/stage-controller.ts`](../src/presenters/stage-controller.ts) | User-Wiki: [Stage-Instrumentierung](../../docs/stage-instrumentation.md) |
+| Strukturbaum-Diffing | [`../src/ui/element-tree.ts`](../src/ui/element-tree.ts), [`../src/presenters/structure-panel.ts`](../src/presenters/structure-panel.ts) | User-Wiki: [Strukturbaum](../../docs/ui-components/structure-tree.md) |
+| Export- & Snapshot-Pipeline | [`../src/state/layout-editor-store.ts`](../src/state/layout-editor-store.ts) | Tests: [`../tests/layout-editor-store.instrumentation.test.ts`](../tests/layout-editor-store.instrumentation.test.ts) |
+
 ## Diff-driven updates
 
 - `DiffRenderer` accepts a host container, a key extractor, and lifecycle hooks (`create`, `update`, `destroy`).
@@ -16,15 +25,15 @@ The component layer now renders through a lightweight diffing helper that keeps 
 3. `StageComponent` emittiert Telemetrie (`StageCameraObserver`), die in [`../../docs/stage-instrumentation.md`](../../docs/stage-instrumentation.md#kamera-telemetrie) mit Nutzerperspektive dokumentiert ist.
 4. Der Nutzer-Workflow ist zusätzlich im User-Wiki unter [Stage-Fokus & Navigation](../../docs/stage-instrumentation.md#kamera-telemetrie) beschrieben.
 
-- `StageComponent` keeps a keyed renderer over canvas nodes. Layout mutations pass through `DiffRenderer`, ensuring that drag/resize operations only repaint the affected element tiles instead of rebuilding the entire stage.
+- `StageComponent` keeps a keyed renderer over canvas nodes. Layout mutations pass through `DiffRenderer`, ensuring that drag/resize operations only repaint the affected element tiles instead of rebuilding the entire stage. See the implementation in [`src/ui/components/stage.ts`](../src/ui/components/stage.ts).
 - Element cursors are cached per snapshot. Pointer handlers resolve parents/children via the cursor map so they never scan the full element list and they can honour the immutable snapshots the store publishes.
 - Selection state is derived inside the shared `syncElementNode` update hook, so toggling selection or dimensions does not trigger unnecessary reflows.
 - Element-specific listeners (pointer move/leave/down) register on the per-node scope. When an element disappears, its interaction listeners disappear with it, preventing leaks between sessions.
 - Drag interactions run inside `LayoutEditorStore.runInteraction()`. The store batches `move`/`resize` plus layout reflows into a single state emission per frame, so the DOM stays in sync without flooding listeners.
 - Drag interactions now call `LayoutEditorStore.flushExport()` once the pointer is released. During the drag, frame updates emit only `state` events, batching export payloads until the interaction settles so JSON serialization does not run on every frame.
-- `StageController` initialises the component with a snapshot, pre-creates container defaults via `ensureContainerDefaults()`, subscribes to the store, and tears everything down in `dispose()`. Its constructor also wires optional camera observers through `StageComponent.observeCamera()`.
+- `StageController` initialises the component with a snapshot, pre-creates container defaults via `ensureContainerDefaults()`, subscribes to the store, and tears everything down in `dispose()`. Its constructor also wires optional camera observers through `StageComponent.observeCamera()`. Details live in [`src/presenters/stage-controller.ts`](../src/presenters/stage-controller.ts).
 - `focusElement()` recentres the camera on the requested element, emits a `StageCameraObserver` event with reason `focus`, and immediately applies the translated transform so other presenters (e.g. the structure panel) can keep camera state and telemetry in lock-step.
-- Camera motions emit `StageCameraObserver` telemetry hooks. Register them through `StageController` and clean them up as described in [Stage instrumentation › Kamera-Telemetrie](../../docs/stage-instrumentation.md#kamera-telemetrie). The `focus` reason is used whenever a tree-driven selection jumps the camera, making analytics correlation trivial.
+- Camera motions emit `StageCameraObserver` telemetry hooks. Register them through `StageController` and clean them up as described in [Stage instrumentation › Kamera-Telemetrie](../../docs/stage-instrumentation.md#kamera-telemetrie). The `focus` reason is used whenever a tree-driven selection jumps the camera, making analytics correlation trivial. Focus propagation across tree and stage is mirrored in [`src/presenters/structure-panel.ts`](../src/presenters/structure-panel.ts).
 
 ## Structure tree component
 
@@ -36,7 +45,7 @@ The component layer now renders through a lightweight diffing helper that keeps 
 
 - The structure tree uses nested diff renderers: the root list and every container node get their own keyed renderer, allowing selective expansion/collapse updates without recreating sibling entries.
 - Entry metadata (title/meta spans, child list, and drag state) stays cached across updates; the diff cycle refreshes text, selection, and child counts in place.
-- Drag-and-drop feedback and drop-zone listeners are routed through component scopes so highlights and drag signals reset automatically after reorder/reparent operations.
+- Drag-and-drop feedback and drop-zone listeners are routed through component scopes so highlights and drag signals reset automatically after reorder/reparent operations. The tree uses [`StructurePanelPresenter.createStateSnapshot`](../src/presenters/structure-panel.ts) to keep drag state and overlays aligned with the store snapshots.
 - `StructurePanelPresenter` feeds selection back into the store and immediately calls `StageController.focusElement()` so the camera jump and the telemetry event fire before the next render. This keeps the canvas centred on the same element as the tree.
 - `onDragStateChange` propagates into `LayoutEditorStore.setDraggedElement()`. Stage overlays and the tree share this state, so active drags stay visually aligned across presenters.
 - Reparent callbacks call `assignElementToContainer()` directly; the store enforces container invariants and publishes the cleared `draggedElementId` when the move finishes.
@@ -62,12 +71,19 @@ The component layer now renders through a lightweight diffing helper that keeps 
 3. Erfolgreiche Wiederholung ruft `clearPersistenceError()` und entfernt Banner/Notice synchron.
 4. Für Nutzer:innen ist der Erwartungswert im User-Wiki unter [Fehlerdiagnose & Qualitätschecks](../../docs/README.md#fehlerdiagnose--qualit%C3%A4tschecks) festgehalten.
 
-- `HeaderControlsPresenter` wires the status banner component so persistence failures surface inline. The presenter normalises thrown errors via `describeLayoutPersistenceError()`, maps them to a deterministic code/description/help trio, and mirrors the same message through an Obsidian `Notice` when the host runtime exposes it.
+- `HeaderControlsPresenter` wires the status banner component so persistence failures surface inline. The presenter normalises thrown errors via `describeLayoutPersistenceError()`, maps them to a deterministic code/description/help trio, and mirrors the same message through an Obsidian `Notice` when the host runtime exposes it. Source: [`src/presenters/header-controls.ts`](../src/presenters/header-controls.ts).
 - `showPersistenceError()` caches the view model, instantiates `StatusBannerComponent` on demand, and mirrors the `noticeMessage` through `showNotice()`, ensuring banner and Obsidian notice stay in sync.
 - `isSavingLayout` keeps the banner stable during retries; once saving succeeds, `clearPersistenceError()` resets the banner and cached error. Import failures opt out of banners and only surface as notices, avoiding stale error chrome.
 - The derived banner state deduplicates raw error messages that already match the curated variants, ensuring the UI renders deterministic, localised content while still exposing unhandled error strings for diagnosis.
 
 Keeping these rules in mind ensures the rendering layer remains incremental, predictable, and cheap to update even for large documents.
+
+## Test coverage & follow-ups
+
+- [`stage-component.test.ts`](../tests/stage-component.test.ts) exercises pointer interactions, drag batching (`runInteraction`) and class toggling for interaction states.
+- [`stage-camera.test.ts`](../tests/stage-camera.test.ts) locks down telemetry sequences for focus, scroll and zoom together with [`StageController`](../src/presenters/stage-controller.ts).
+- [`layout-editor-store.instrumentation.test.ts`](../tests/layout-editor-store.instrumentation.test.ts) asserts `clamp:step` emission and canvas snapping behaviour.
+- **Gap:** Keyboard shortcuts (tree ↔ stage) are not covered by automated tests. Follow-up To-Do: [`../todo/ui-shortcut-coverage.md`](../todo/ui-shortcut-coverage.md).
 
 ## Navigation
 
@@ -76,5 +92,5 @@ Keeping these rules in mind ensures the rendering layer remains incremental, pre
 
 ## Offene Aufgaben
 
-- Interaktions- und Performance-Dokumentation konsolidieren: [`documentation-audit-ui-experience.md`](../todo/documentation-audit-ui-experience.md).
 - Diagramme & Accessibility-Guidelines ergänzen: [`ui-accessibility-and-diagrams.md`](../todo/ui-accessibility-and-diagrams.md).
+- Shortcut-Testabdeckung ergänzen: [`ui-shortcut-coverage.md`](../todo/ui-shortcut-coverage.md).

--- a/layout-editor/src/elements/README.md
+++ b/layout-editor/src/elements/README.md
@@ -24,6 +24,15 @@ elements/
 | [`shared/`](./shared/README.md) | Enthält wiederverwendbare Basisklassen und Renderer für Element-Previews. Details in der [Shared-Dokumentation](./shared/README.md). |
 | [`components/`](./components/README.md) | Konkrete Elementimplementierungen für Palette & Stage. Übersicht in der [Komponenten-Dokumentation](./components/README.md). |
 
+## Dokumentationsinventar
+
+| Thema | Technische Quelle | Soll-Referenz (User-Wiki) |
+| --- | --- | --- |
+| Elemente-Basisklassen & Manifest | [`base.ts`](./base.ts), [`component-manifest.ts`](./component-manifest.ts) | [UI-Komponenten › Bibliothek & Palette](../../../docs/ui-components.md#ui-komponenten-im-%C3%BCberblick) |
+| Palette-Interaktionen | [`ui.ts`](./ui.ts), [`components/`](./components/README.md) | [Stage-Bedienkonzept › Drag-Szenario](../../../docs/stage-instrumentation.md#tests--qualit%C3%A4tssicherung) |
+| Inspector-Anbindung | [`ui.ts`](./ui.ts), [`../presenters/structure-panel.ts`](../presenters/structure-panel.ts) | [Setup-Workflows › View-Bindings](../../../docs/README.md#setup-workflows) |
+| Performance & Rendering | [`../ui/components`](../ui/components) | [UI-Performance](../../docs/ui-performance.md) |
+
 ## Arbeitsfluss
 
 1. **Komponente ableiten:** Neue Elemente bauen auf den Basisklassen aus [`shared/component-bases.ts`](./shared/component-bases.ts) auf oder implementieren `LayoutElementComponent` direkt.
@@ -48,7 +57,28 @@ elements/
 1. Neue Komponenten werden in `components/` abgelegt.
 2. `npm run build` führt das Manifest-Script aus und registriert die Komponente in `component-manifest.ts`.
 3. `registry.ts` stellt die Definition bereit; Palette, Stage und Inspector erhalten sie beim nächsten Import.
-4. Offene Diagramme für diesen Ablauf sind im To-Do [`ui-accessibility-and-diagrams.md`](../../todo/ui-accessibility-and-diagrams.md) hinterlegt.
+
+### Sequenzdiagramm: Drag & Drop Palette → Stage
+
+```mermaid
+sequenceDiagram
+    participant User as Nutzer:in
+    participant Palette as createElementsField
+    participant Presenter as StructurePanelPresenter
+    participant Store as LayoutEditorStore
+    participant Stage as StageComponent
+    User->>Palette: Start Drag auf Elementdefinition
+    Palette->>Presenter: onDragStart(definitionId)
+    Presenter->>Store: addElementFromDefinition(definitionId)
+    Store-->>Stage: Snapshot mit neuem Element (draggedElementId)
+    Stage-->>User: Vorschau & Drop-Ziel anzeigen
+    User->>Stage: Drop auf Canvas
+    Stage->>Store: runInteraction() + flushExport()
+    Store-->>Presenter: Snapshot (draggedElementId = null)
+    Presenter-->>User: Palette bestätigt Abschluss
+```
+
+Die Sequenz deckt den Soll-Ablauf „Palette → Stage“ aus dem User-Wiki ab ([Tests & Qualitätssicherung › Drag-Szenario](../../../docs/stage-instrumentation.md#tests--qualit%C3%A4tssicherung)). Automatisierte Coverage für Palette-Registrierungen befindet sich in [`../../tests/view-registry.test.ts`](../../tests/view-registry.test.ts). Offene Diagramme für angrenzende A11y-Aspekte sind im To-Do [`ui-accessibility-and-diagrams.md`](../../todo/ui-accessibility-and-diagrams.md) hinterlegt.
 
 ## Registry- & Manifest-Pipeline
 
@@ -70,5 +100,5 @@ elements/
 
 ## Offene Punkte
 
-- Workflow- und Querverweis-Review: [`documentation-audit-ui-experience.md`](../../todo/documentation-audit-ui-experience.md).
 - Sequenzdiagramme & Barrierefreiheit: [`ui-accessibility-and-diagrams.md`](../../todo/ui-accessibility-and-diagrams.md).
+- Shortcut-Testabdeckung ergänzen: [`ui-shortcut-coverage.md`](../../todo/ui-shortcut-coverage.md).

--- a/layout-editor/src/presenters/README.md
+++ b/layout-editor/src/presenters/README.md
@@ -12,6 +12,15 @@ presenters/
 └── structure-panel.ts     – StructurePanelPresenter für Tree-Auswahl & Drag/Drop
 ```
 
+## Dokumentationsinventar
+
+| Thema | Technische Quelle | Soll-Referenz (User-Wiki) |
+| --- | --- | --- |
+| Fokus- & Kamera-Kopplung | [`stage-controller.ts`](./stage-controller.ts) | [Stage-Instrumentierung › Kamera-Telemetrie](../../../docs/stage-instrumentation.md#kamera-telemetrie) |
+| Strukturbaum-Delegation | [`structure-panel.ts`](./structure-panel.ts) | [UI-Komponenten › Strukturbaum](../../../docs/ui-components/structure-tree.md#prim%C3%A4re-interaktionen) |
+| Persistenz-Feedback | [`header-controls.ts`](./header-controls.ts) | [User-Wiki › Fehlerdiagnose & Qualitätschecks](../../../docs/README.md#fehlerdiagnose--qualit%C3%A4tschecks) |
+| Shortcuts & Keyboard-Brücke | [`stage-controller.ts`](./stage-controller.ts), [`../ui/components/stage.ts`](../ui/components/stage.ts) | [UI-Komponenten › Keyboard-Shortcuts](../../../docs/ui-components.md#keyboard-shortcuts) |
+
 ## Terminologie & Rollen
 
 - **StageController** – Verbindet Canvas, Kamera-Telemetrie und Store-Snapshots.
@@ -45,6 +54,32 @@ presenters/
 2. Fehler werden über `describeLayoutPersistenceError()` normalisiert und via `showPersistenceError()` sowohl an `StatusBannerComponent` als auch `showNotice()` weitergegeben.
 3. `clearPersistenceError()` entfernt Banner/Notice, sobald ein erfolgreicher Speichervorgang gemeldet wird.
 4. Anwenderleitfaden siehe [User-Wiki › Fehlerdiagnose & Qualitätschecks](../../../docs/README.md#fehlerdiagnose--qualit%C3%A4tschecks).
+
+### Shortcuts Tree ⇄ Stage
+
+```mermaid
+sequenceDiagram
+    participant User as Nutzer:in
+    participant Tree as StructureTreeComponent
+    participant Presenter as StructurePanelPresenter
+    participant StageCtrl as StageController
+    participant Stage as StageComponent
+    participant Store as LayoutEditorStore
+    User->>Tree: ArrowDown (Tree-Navigation)
+    Tree->>Presenter: onSelectElement(nextId)
+    Presenter->>Store: selectElement(nextId)
+    Presenter->>StageCtrl: focusElement(nextId)
+    StageCtrl->>Stage: focusElement(nextId)
+    Stage->>StageCtrl: StageCameraObserver(reason="focus")
+    StageCtrl->>Presenter: notifyFocus(reason)
+    Stage->>User: Auswahl & Kamera aktualisiert
+    User->>Stage: Shift+Arrow (Resize-Shortcut)
+    Stage->>Store: runInteraction(resize)
+    Store-->>Stage: Snapshot & clampEvents
+    Store-->>Presenter: state (selectedElementId)
+```
+
+Die Shortcut-Kette folgt den Vorgaben aus dem User-Wiki ([UI-Komponenten › Keyboard-Shortcuts](../../../docs/ui-components.md#keyboard-shortcuts)). Aktuell decken [`../../tests/stage-camera.test.ts`](../../tests/stage-camera.test.ts) Fokus-Telemetrie, nicht aber die Tastenevents selbst ab; siehe To-Do [`ui-shortcut-coverage.md`](../../todo/ui-shortcut-coverage.md).
 
 ## StageController (`stage-controller.ts`)
 
@@ -93,5 +128,5 @@ Der Header-Presenter bündelt Element-Picker, Canvas-Größeneingaben, Exportans
 
 ## Offene Punkte
 
-- Dokumentationslücken und Workflow-Abgleich siehe [`documentation-audit-ui-experience.md`](../../todo/documentation-audit-ui-experience.md).
 - Sequenzdiagramme & Accessibility-Kriterien ergänzen: [`ui-accessibility-and-diagrams.md`](../../todo/ui-accessibility-and-diagrams.md).
+- Shortcut-Testabdeckung ergänzen: [`ui-shortcut-coverage.md`](../../todo/ui-shortcut-coverage.md).

--- a/layout-editor/src/ui/README.md
+++ b/layout-editor/src/ui/README.md
@@ -14,6 +14,15 @@ ui/
 └── utils.ts           – Einstiegspunkt für modulübergreifende Helfer
 ```
 
+## Dokumentationsinventar
+
+| Thema | Technische Quelle | Soll-Referenz (User-Wiki) |
+| --- | --- | --- |
+| Stage- und Tree-Komponenten | [`components/`](components/README.md) | [Tests & Qualitätssicherung › Drag-Szenario](../../../docs/stage-instrumentation.md#tests--qualit%C3%A4tssicherung) |
+| Kontextmenüs & Aktionen | [`editor-menu.ts`](editor-menu.ts) | [UI-Komponenten › Shell & Banner](../../../docs/ui-components.md#ui-komponenten-im-%C3%BCberblick) |
+| Element-Baum & Bibliothek | [`element-tree.ts`](element-tree.ts) | [UI-Komponenten › Strukturbaum](../../../docs/ui-components/structure-tree.md) |
+| Performance-Leitplanken | [`../../docs/ui-performance.md`](../../docs/ui-performance.md) | [Stage-Instrumentierung](../../../docs/stage-instrumentation.md) |
+
 ## Inhalte
 - [`components/`](components/README.md) – Sammlung der komplexen UI-Komponenten (Stage, DiffRenderer, Shell usw.).
 - [`editor-menu.ts`](editor-menu.ts) – Erzeugt kontextuelle Aktionsmenüs für Canvas- und Bauminteraktionen.
@@ -57,6 +66,23 @@ Aus Anwendersicht ist dieser Ablauf im [User-Wiki › Stage-Bedienkonzept](../..
 
 Für den Nutzerablauf siehe [User-Wiki › Setup-Workflows › View-Bindings](../../../docs/README.md#setup-workflows).
 
+### Canvas-Snapping (Clamping) Sequenz
+
+```mermaid
+sequenceDiagram
+    participant User as Nutzer:in
+    participant Stage as StageComponent
+    participant Store as LayoutEditorStore
+    participant Telemetry as StageInteractionTelemetry
+    User->>Stage: Pointer-Drag erreicht Canvas-Rand
+    Stage->>Store: runInteraction() mit geclampter Position
+    Store-->>Stage: Snapshot mit "snapped" Elementkoordinaten
+    Store->>Telemetry: clamp:step (elementId, previous, result)
+    Stage-->>User: Visuelles Snapping & Live-Region Meldung
+```
+
+Der Ablauf entspricht dem Soll-Zustand „Canvas-Clamp“ aus dem User-Wiki ([Tests & Qualitätssicherung › Drag-Szenario](../../../docs/stage-instrumentation.md#tests--qualit%C3%A4tssicherung)). `StageComponent` meldet das Snapping synchron an Presenter und Telemetrie; Tests für die Eventfolge befinden sich in [`../../tests/layout-editor-store.instrumentation.test.ts`](../../tests/layout-editor-store.instrumentation.test.ts).
+
 ## Weiterführende Dokumentation
 - Architektur-Überblick: [`../README.md`](../README.md)
 - Performance-Guidelines für UI-Widgets: [`../../docs/ui-performance.md`](../../docs/ui-performance.md)
@@ -66,5 +92,5 @@ Für den Nutzerablauf siehe [User-Wiki › Setup-Workflows › View-Bindings](..
 
 ## Offene Punkte
 
-- Dokumentationsabgleich für Interaktionen und Presenter: [`documentation-audit-ui-experience.md`](../../todo/documentation-audit-ui-experience.md).
 - Sequenzdiagramme & A11y-Kriterien ergänzen: [`ui-accessibility-and-diagrams.md`](../../todo/ui-accessibility-and-diagrams.md).
+- Shortcut-Testabdeckung ergänzen: [`ui-shortcut-coverage.md`](../../todo/ui-shortcut-coverage.md).

--- a/todo/README.md
+++ b/todo/README.md
@@ -7,7 +7,8 @@ Dieses Verzeichnis sammelt alle offenen To-Dos für den Layout-Editor. Jede Date
 - `README.md` – Index des Backlogs, beschreibt Struktur, Konventionen und Metadaten-Standard.
 - `documentation-audit-state-model.md` – Audit der Dokumentation für State-, Datenmodell- und History-Flows (Status: geschlossen).
 - `ui-components-wiki.md` – Ausbau des UI-Komponenten-Wikis (Status: geschlossen).
-- `documentation-audit-ui-experience.md` – Review der UI-, Presenter- und Interaktionsdokumentation.
+- `documentation-audit-ui-experience.md` – Review der UI-, Presenter- und Interaktionsdokumentation (Status: geschlossen).
+- `ui-shortcut-coverage.md` – Automatisierte Tests für Shortcut-Workflows (Stage/Tree/Header).
 - `documentation-audit-configuration-settings.md` – Überprüfung der Konfigurations- und Settings-Dokumentation.
 - `documentation-audit-integration-api.md` – Validierung der Integrations- und Plugin-API-Dokumente.
 - `store-snapshot-immutability-tests.md` – Regressionstest für unveränderliche Store-Snapshots.
@@ -17,11 +18,11 @@ Dieses Verzeichnis sammelt alle offenen To-Dos für den Layout-Editor. Jede Date
 
 | Datei | Kategorie | Priorität | Kurzbeschreibung |
 | --- | --- | --- | --- |
-| [`documentation-audit-ui-experience.md`](documentation-audit-ui-experience.md) | Dokumentation | Mittel | UI-, Presenter- und Workflow-Dokumentation auf Lücken prüfen. |
 | [`documentation-audit-configuration-settings.md`](documentation-audit-configuration-settings.md) | Dokumentation | Mittel | Konfigurations-, Settings- und Fehlerpfad-Dokumentation abgleichen. |
 | [`documentation-audit-integration-api.md`](documentation-audit-integration-api.md) | Dokumentation | Mittel | Integrations- und Plugin-API-Guides auf Vollständigkeit prüfen. |
 | [`store-snapshot-immutability-tests.md`](store-snapshot-immutability-tests.md) | Tests | Mittel | Regressionstest sicherstellen, dass Store-Snapshots außerhalb des Stores nicht mutiert werden können. |
 | [`ui-accessibility-and-diagrams.md`](ui-accessibility-and-diagrams.md) | Dokumentation | Mittel | Sequenzdiagramme und Barrierefreiheit für UI-Flows definieren. |
+| [`ui-shortcut-coverage.md`](ui-shortcut-coverage.md) | Tests | Mittel | Shortcut-Workflows (Tree ↔ Stage ↔ Header) automatisiert absichern. |
 
 Sobald neuer Handlungsbedarf entsteht, lege eine eigene Markdown-Datei in diesem Ordner an und verlinke sie in dieser Tabelle nach Priorität.
 
@@ -37,3 +38,4 @@ Sobald neuer Handlungsbedarf entsteht, lege eine eigene Markdown-Datei in diesem
 
 - [`documentation-audit-state-model.md`](documentation-audit-state-model.md) – Audit abgeschlossen, Ergebnis siehe Abschnitt „Ergebnis (2025-09-27)“ innerhalb der Datei.
 - [`ui-components-wiki.md`](ui-components-wiki.md) – Informationsarchitektur abgeschlossen, Ergebnis siehe Abschnitt „Ergebnis (2025-02-14)“.
+- [`documentation-audit-ui-experience.md`](documentation-audit-ui-experience.md) – Dokumentationsabgleich abgeschlossen, Ergebnis siehe Abschnitt „Ergebnis (2025-03-18)“.

--- a/todo/documentation-audit-ui-experience.md
+++ b/todo/documentation-audit-ui-experience.md
@@ -1,10 +1,10 @@
 ---
-status: open
+status: closed
 priority: medium
 area:
   - documentation
   - ui
-owner: unassigned
+owner: docs-team
 tags:
   - presenters
   - interaction-design
@@ -32,7 +32,14 @@ links:
 - `layout-editor/docs/layout-library.md`
 
 ## Lösungsideen
-- Abläufe für zentrale Interaktionen als Sequenz- oder Aktivitätsdiagramm dokumentieren und in den Modul-Readmes verankern.
-- Tastenkürzel, Gesten und Barrierefreiheitsanforderungen im User-Wiki abgleichen und sicherstellen, dass technische Readmes auf die Soll-Prozesse verweisen.
-- Performance-Guidelines mit konkreten Beispielen aus den UI-Modulen ergänzen und gegenseitig verlinken.
-- Validieren, dass Tests die dokumentierten Workflows abdecken, und fehlende Szenarien als weitere To-Dos erfassen.
+- ✅ Abläufe für zentrale Interaktionen als Sequenz- oder Aktivitätsdiagramm dokumentieren und in den Modul-Readmes verankern.
+- ✅ Tastenkürzel, Gesten und Barrierefreiheitsanforderungen im User-Wiki abgleichen und sicherstellen, dass technische Readmes auf die Soll-Prozesse verweisen.
+- ✅ Performance-Guidelines mit konkreten Beispielen aus den UI-Modulen ergänzen und gegenseitig verlinken.
+- ⚠️ Validieren, dass Tests die dokumentierten Workflows abdecken, und fehlende Szenarien als weitere To-Dos erfassen. Folgepunkt: [`ui-shortcut-coverage.md`](ui-shortcut-coverage.md).
+
+## Ergebnis (2025-03-18)
+
+- `src/ui/README.md`, `src/elements/README.md` und `src/presenters/README.md` enthalten nun Inventar-Tabellen, verlinken die Soll-Workflows des User-Wikis und visualisieren Drag-, Snapping- und Shortcut-Sequenzen über Mermaid-Diagramme.
+- `docs/ui-performance.md` referenziert konkrete Implementierungen (`StageComponent`, `StageController`, `StructurePanelPresenter`, `LayoutEditorStore`) sowie vorhandene Tests; fehlende Shortcut-Tests wurden als eigenes To-Do erfasst.
+- `docs/layout-library.md` dokumentiert die Verflechtung mit Header-Präsentern und verweist auf Tests (`persistence-errors.test.ts`, `api-versioning.test.ts`), damit Performance- und Fehlerpfade nachvollziehbar bleiben.
+- Offene Restarbeit betrifft ausschließlich Shortcut-Testabdeckung, weshalb das Nachfolge-To-Do [`ui-shortcut-coverage.md`](ui-shortcut-coverage.md) angelegt wurde.

--- a/todo/ui-shortcut-coverage.md
+++ b/todo/ui-shortcut-coverage.md
@@ -1,0 +1,38 @@
+---
+status: open
+priority: medium
+area:
+  - tests
+  - ui
+owner: unassigned
+tags:
+  - shortcuts
+  - presenters
+  - stage
+links:
+  - layout-editor/src/ui/README.md
+  - layout-editor/src/presenters/README.md
+  - layout-editor/docs/ui-performance.md
+---
+
+# Shortcut-Workflows automatisiert absichern
+
+## Originalkritik
+- Die aktualisierten UI-Dokumente beschreiben Shortcut-Sequenzen (Tree ↔ Stage ↔ Header) inklusive Telemetrie-Erwartungen, jedoch existieren keine automatisierten Tests, die Tastaturinteraktionen gegen den Store oder Presenter verifizieren.
+
+## Kontext
+- Tree- und Stage-Komponenten koordinieren Fokus, Auswahl und Kamera über Presenter (`StructurePanelPresenter`, `StageController`).
+- Keyboard-Shortcuts sind im User-Wiki als Soll-Zustand dokumentiert ([UI-Komponenten › Keyboard-Shortcuts](../docs/ui-components.md#keyboard-shortcuts)).
+- Performance-Guidelines fordern stabile Batch-Verarbeitung (`runInteraction`, `flushExport`), die bislang nur über Pointer-Szenarien getestet wird.
+
+## Betroffene Module
+- `layout-editor/src/presenters/structure-panel.ts`
+- `layout-editor/src/presenters/stage-controller.ts`
+- `layout-editor/src/ui/components/stage.ts`
+- `layout-editor/tests`
+
+## Lösungsideen
+- Integrationstests schreiben, die Tree-Keyboard-Events simulieren (`ArrowUp/Down`, `Enter`, `Shift+Arrow`) und den resultierenden Fokus/Export-State prüfen.
+- Telemetrie-Logger (`stageInteractionTelemetry`, `StageCameraObserver`) mocken und Sequenzen für Keyboard-gestützte Bewegungen/Snapping verifizieren.
+- Header-Pfad (`HeaderControlsPresenter`) auf Shortcut-Benachrichtigungen prüfen, um Bibliotheksstatus und Notices zu testen.
+- Erfolgsnachweis in den Modul-Readmes verlinken, sobald Tests vorliegen.


### PR DESCRIPTION
## Summary
- add documentation inventories to UI-, Elements- and Presenters-Readmes and align terminology with the user wiki
- document drag, snapping and shortcut flows via Mermaid diagrams and link UI performance guidance to concrete modules and tests
- close the UI documentation audit, add a shortcut test coverage follow-up and update the todo index

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d7ba7faeb08325ba920437855c2678